### PR TITLE
Adds proper expressions as filter values

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -44,17 +44,26 @@ export type Operator = ComparisonOperator | CombinationOperator | NegationOperat
 export interface Filter extends Array<any> {}
 
 /**
+ * A base interface for expressions.
+ */
+export interface AbstractExpression {
+  type: string;
+}
+
+/**
  * Expression that evaluates to the given value.
  */
-export interface LiteralValue {
+export interface LiteralValue extends AbstractExpression {
   value: RegExp|string|number|boolean|null;
+  type: 'literal';
 }
 
 /**
  * Expression that evaluates to the value of the given property.
  */
-export interface PropertyName {
+export interface PropertyName extends AbstractExpression {
   name: string;
+  type: 'property';
 }
 
 /**
@@ -64,6 +73,7 @@ export interface PropertyName {
 export interface FunctionCall {
   name: string;
   args: Expression[];
+  type: 'functioncall';
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -63,7 +63,7 @@ export interface PropertyName {
  */
 export interface FunctionCall {
   name: string;
-  arguments: Expression[];
+  args: Expression[];
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -44,29 +44,40 @@ export type Operator = ComparisonOperator | CombinationOperator | NegationOperat
 export interface Filter extends Array<any> {}
 
 /**
- * A FunctionFilter that expects a string (propertyName) as second arguement and
- * a regular expression as third argument. An actual parser implementation has to
- * return a value for this function expression.
+ * Expression that evaluates to the given value.
  */
-export interface StrMatchesFunctionFilter extends Filter {
-  0: 'FN_strMatches';
-  1: string;
-  2: RegExp;
+export interface LiteralValue {
+  value: RegExp|string|number|boolean|null;
 }
 
 /**
- * A Filter that expresses a function.
+ * Expression that evaluates to the value of the given property.
  */
-export type FunctionFilter = StrMatchesFunctionFilter;
+export interface PropertyName {
+  name: string;
+}
 
 /**
- * A ComparisonFilter compares a value of an object (by key) with an expected
- * value.
+ * Expression that evaluates to the result of a function call on
+ * a list of argument expressions.
+ */
+export interface FunctionCall {
+  name: string;
+  arguments: Expression[];
+}
+
+/**
+ * Expressions can be a literal value, a property name or a function call.
+ */
+export type Expression = LiteralValue | PropertyName | FunctionCall;
+
+/**
+ * A ComparisonFilter compares two expressions.
  */
 export interface ComparisonFilter extends Filter {
   0: ComparisonOperator;
-  1: string | FunctionFilter;
-  2: string|number|boolean|null;
+  1: Expression;
+  2: Expression;
 }
 
 /**


### PR DESCRIPTION
This adds support for all kinds of expressions as filter values. This closely adheres to filter encoding 2.0 and allows expressions for both arguments to comparison operators.

@terrestris/devs Please review.
