### PR TITLE
Allow ttf:// scheme for well known names in mark symbolizer

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -150,11 +150,20 @@ export interface BasePointSymbolizer extends BaseSymbolizer {
 
 /**
  * Supported WellKnownNames
+ * Note that due to TypeScript limitations any string will be valid for this type; this will not change
+ * until regexp or equivalent is supported, see:
+ * https://github.com/microsoft/TypeScript/issues/6579
+ *
+ * Important: Geostyler Style Parsers are only expected to support the values listed below,
+ * as well as font-based symbols following Geotools/Geoserver syntax:
+ * ttf://<font name>#<hex code>
  */
 export type WellKnownName = 'Circle' | 'Square' | 'Triangle' | 'Star' | 'Cross' | 'X'
 | 'shape://vertline' | 'shape://horline' | 'shape://slash'
 | 'shape://backslash' | 'shape://dot' | 'shape://plus'
-| 'shape://times' | 'shape://oarrow' | 'shape://carrow' ;
+| 'shape://times' | 'shape://oarrow' | 'shape://carrow'
+| 'ttf://Webdings#0x0064'
+| string;
 
 /**
  * MarkSymbolizer describes the style representation of POINT data, if styled as

--- a/sample.ts
+++ b/sample.ts
@@ -71,6 +71,13 @@ const sampleStyle: Style = {
         wellKnownName: 'Circle',
         visibility: false,
         radius: 5
+      }, {
+        kind: 'Mark',
+        wellKnownName: 'ttf://Webdings#0x68',
+        radius: 12,
+        color: '#8a000e',
+        strokeOpacity: 0.7,
+        strokeColor: '#ffffff'
       }]
     },
     {


### PR DESCRIPTION
Typescript does not allow yet doing strong validation on strings, so we have to resort to allowing any string for WellKnownName type.

I have taken the liberty to add a random value using a font glyph to the existing ones, not for actual validation but more as an illustration/hint.

Discussed in https://github.com/geostyler/geostyler-sld-parser/issues/277