### PR TITLE
Filter typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -29,12 +29,12 @@ export type PropertyName = string;
 export type PropertyValue = string|number|boolean|null;
 
 /**
- * The possible Operator used for comparison Filters.
+ * The possible Operators used for comparison Filters.
  */
 export type ComparisonOperator = '==' | '*=' | '!=' | '<' | '<=' | '>' | '>=';
 
 /**
- * The possible Operator used for combination Filters.
+ * The possible Operators used for combination Filters.
  */
 export type CombinationOperator = '&&' | '||';
 
@@ -54,7 +54,7 @@ export type StrMatchesFunctionOperator = 'FN_strMatches';
 export type Operator = ComparisonOperator | CombinationOperator | NegationOperator | StrMatchesFunctionOperator;
 
 /**
- * A FunctionFilter that expects a string (propertyName) as second arguement and
+ * A FunctionFilter that expects a string (propertyName) as second argument and
  * a regular expression as third argument. An actual parser implementation has to
  * return a value for this function expression.
  */
@@ -81,10 +81,6 @@ export type ComparisonFilter = [
 
 /**
  * A CombinationFilter combines N Filters with a logical OR / AND operator.
- *
- * This is just type secure for a maximum of 10 combined filters as you can't
- * type 'rest' parameters of an array. Nevertheless, theoreticaly you can
- * combine >10 filters.
  */
 export type CombinationFilter = [
   CombinationOperator,

--- a/index.d.ts
+++ b/index.d.ts
@@ -26,7 +26,7 @@ export type PropertyName = string;
 /**
  * A value of a property of the data.
  */
-export type PropertyValue = string|number|boolean|null;
+export type PropertyValue = string | number | boolean | null;
 
 /**
  * The possible Operators used for comparison Filters.

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,16 @@ export interface ScaleDenominator {
 export type StyleType = 'Point' | 'Fill' | 'Line' | 'Raster';
 
 /**
+ * A name of a property of the data.
+ */
+export type PropertyName = string;
+
+/**
+ * A value of a property of the data.
+ */
+export type PropertyValue = string|number|boolean|null;
+
+/**
  * The possible Operator used for comparison Filters.
  */
 export type ComparisonOperator = '==' | '*=' | '!=' | '<' | '<=' | '>' | '>=';
@@ -34,25 +44,25 @@ export type CombinationOperator = '&&' | '||';
 export type NegationOperator = '!';
 
 /**
- * All operators.
+ * The Operator used for functional Filters.
  */
-export type Operator = ComparisonOperator | CombinationOperator | NegationOperator;
+export type StrMatchesFunctionOperator = 'FN_strMatches';
 
 /**
- * A base interface for Filter.
+ * All operators.
  */
-export interface Filter extends Array<any> {}
+export type Operator = ComparisonOperator | CombinationOperator | NegationOperator | StrMatchesFunctionOperator;
 
 /**
  * A FunctionFilter that expects a string (propertyName) as second arguement and
  * a regular expression as third argument. An actual parser implementation has to
  * return a value for this function expression.
  */
-export interface StrMatchesFunctionFilter extends Filter {
-  0: 'FN_strMatches';
-  1: string;
-  2: RegExp;
-}
+export type StrMatchesFunctionFilter = [
+  StrMatchesFunctionOperator,
+  PropertyName,
+  RegExp
+];
 
 /**
  * A Filter that expresses a function.
@@ -63,11 +73,11 @@ export type FunctionFilter = StrMatchesFunctionFilter;
  * A ComparisonFilter compares a value of an object (by key) with an expected
  * value.
  */
-export interface ComparisonFilter extends Filter {
-  0: ComparisonOperator;
-  1: string | FunctionFilter;
-  2: string|number|boolean|null;
-}
+export type ComparisonFilter = [
+  ComparisonOperator,
+  PropertyName | FunctionFilter,
+  PropertyValue
+];
 
 /**
  * A CombinationFilter combines N Filters with a logical OR / AND operator.
@@ -76,28 +86,20 @@ export interface ComparisonFilter extends Filter {
  * type 'rest' parameters of an array. Nevertheless, theoreticaly you can
  * combine >10 filters.
  */
-export interface CombinationFilter extends Filter  {
-  0: CombinationOperator;
-  1: Filter;
-  2: Filter;
-  3?: Filter;
-  4?: Filter;
-  5?: Filter;
-  6?: Filter;
-  7?: Filter;
-  8?: Filter;
-  9?: Filter;
-  10?: Filter;
-  11?: Filter;
-}
+export type CombinationFilter = [
+  CombinationOperator,
+  ...Filter[]
+];
 
 /**
  * A NegationFilter negates a given Filter.
  */
-export interface NegationFilter extends Filter  {
-  0: NegationOperator;
-  1: Filter;
-}
+export type NegationFilter = [
+  NegationOperator,
+  Filter
+];
+
+export type Filter = FunctionFilter | ComparisonFilter | NegationFilter | CombinationFilter;
 
 /**
  * The kind of the Symbolizer

--- a/schema.json
+++ b/schema.json
@@ -63,10 +63,10 @@
             "additionalItems": {
                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Filter"
             },
-            "description": "A CombinationFilter combines N Filters with a logical OR / AND operator.\n\nThis is just type secure for a maximum of 10 combined filters as you can't\ntype 'rest' parameters of an array. Nevertheless, theoreticaly you can\ncombine >10 filters.",
+            "description": "A CombinationFilter combines N Filters with a logical OR / AND operator.",
             "items": [
                 {
-                    "description": "The possible Operator used for combination Filters.",
+                    "description": "The possible Operators used for combination Filters.",
                     "enum": [
                         "&&",
                         "||"
@@ -162,7 +162,7 @@
         "Filter": {
             "anyOf": [
                 {
-                    "description": "A FunctionFilter that expects a string (propertyName) as second arguement and\na regular expression as third argument. An actual parser implementation has to\nreturn a value for this function expression.",
+                    "description": "A FunctionFilter that expects a string (propertyName) as second argument and\na regular expression as third argument. An actual parser implementation has to\nreturn a value for this function expression.",
                     "items": [
                         {
                             "enum": [
@@ -185,7 +185,7 @@
                     "description": "A ComparisonFilter compares a value of an object (by key) with an expected\nvalue.",
                     "items": [
                         {
-                            "description": "The possible Operator used for comparison Filters.",
+                            "description": "The possible Operators used for comparison Filters.",
                             "enum": [
                                 "!=",
                                 "*=",
@@ -200,7 +200,7 @@
                         {
                             "anyOf": [
                                 {
-                                    "description": "A FunctionFilter that expects a string (propertyName) as second arguement and\na regular expression as third argument. An actual parser implementation has to\nreturn a value for this function expression.",
+                                    "description": "A FunctionFilter that expects a string (propertyName) as second argument and\na regular expression as third argument. An actual parser implementation has to\nreturn a value for this function expression.",
                                     "items": [
                                         {
                                             "enum": [

--- a/schema.json
+++ b/schema.json
@@ -59,6 +59,24 @@
             ],
             "type": "string"
         },
+        "CombinationFilter": {
+            "additionalItems": {
+                "$ref": "http://geostyler/geostyler-style.json#/definitions/Filter"
+            },
+            "description": "A CombinationFilter combines N Filters with a logical OR / AND operator.\n\nThis is just type secure for a maximum of 10 combined filters as you can't\ntype 'rest' parameters of an array. Nevertheless, theoreticaly you can\ncombine >10 filters.",
+            "items": [
+                {
+                    "description": "The possible Operator used for combination Filters.",
+                    "enum": [
+                        "&&",
+                        "||"
+                    ],
+                    "type": "string"
+                }
+            ],
+            "minItems": 1,
+            "type": "array"
+        },
         "ContrastEnhancement": {
             "description": "A ContrastEnhancement defines how the contrast of image data should be enhanced.",
             "properties": {
@@ -140,6 +158,106 @@
                 }
             },
             "type": "object"
+        },
+        "Filter": {
+            "anyOf": [
+                {
+                    "description": "A FunctionFilter that expects a string (propertyName) as second arguement and\na regular expression as third argument. An actual parser implementation has to\nreturn a value for this function expression.",
+                    "items": [
+                        {
+                            "enum": [
+                                "FN_strMatches"
+                            ],
+                            "type": "string"
+                        },
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/RegExp"
+                        }
+                    ],
+                    "maxItems": 3,
+                    "minItems": 3,
+                    "type": "array"
+                },
+                {
+                    "description": "A ComparisonFilter compares a value of an object (by key) with an expected\nvalue.",
+                    "items": [
+                        {
+                            "description": "The possible Operator used for comparison Filters.",
+                            "enum": [
+                                "!=",
+                                "*=",
+                                "<",
+                                "<=",
+                                "==",
+                                ">",
+                                ">="
+                            ],
+                            "type": "string"
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "description": "A FunctionFilter that expects a string (propertyName) as second arguement and\na regular expression as third argument. An actual parser implementation has to\nreturn a value for this function expression.",
+                                    "items": [
+                                        {
+                                            "enum": [
+                                                "FN_strMatches"
+                                            ],
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/RegExp"
+                                        }
+                                    ],
+                                    "maxItems": 3,
+                                    "minItems": 3,
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        {
+                            "description": "A value of a property of the data.",
+                            "type": [
+                                "string",
+                                "number",
+                                "boolean"
+                            ]
+                        }
+                    ],
+                    "maxItems": 3,
+                    "minItems": 3,
+                    "type": "array"
+                },
+                {
+                    "$ref": "http://geostyler/geostyler-style.json#/definitions/CombinationFilter"
+                },
+                {
+                    "description": "A NegationFilter negates a given Filter.",
+                    "items": [
+                        {
+                            "enum": [
+                                "!"
+                            ],
+                            "type": "string"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Filter"
+                        }
+                    ],
+                    "maxItems": 2,
+                    "minItems": 2,
+                    "type": "array"
+                }
+            ]
         },
         "GrayChannel": {
             "description": "A GrayChannel defines how a single dataset band is mapped to a grayscale channel.",
@@ -592,17 +710,43 @@
             },
             "type": "object"
         },
+        "RegExp": {
+            "properties": {
+                "dotAll": {
+                    "type": "boolean"
+                },
+                "flags": {
+                    "type": "string"
+                },
+                "global": {
+                    "type": "boolean"
+                },
+                "ignoreCase": {
+                    "type": "boolean"
+                },
+                "lastIndex": {
+                    "type": "number"
+                },
+                "multiline": {
+                    "type": "boolean"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "sticky": {
+                    "type": "boolean"
+                },
+                "unicode": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
         "Rule": {
             "description": "A Rule combines a specific amount of data (defined by a Filter and a\nScaleDenominator) and an associated Symbolizer.",
             "properties": {
                 "filter": {
-                    "additionalProperties": false,
-                    "description": "A base interface for Filter.",
-                    "patternProperties": {
-                        "^[0-9]+$": {
-                        }
-                    },
-                    "type": "object"
+                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Filter"
                 },
                 "name": {
                     "type": "string"
@@ -850,3 +994,4 @@
     },
     "type": "object"
 }
+


### PR DESCRIPTION
## TypeChange
This updates the typing for filters. In TypeScript >3 you can be more precise when defining arrays. Also you don't need interfaces but can use `type` directly.

This change may crash the linting of existing implementations as the filters are herewith typed more precise.
Previously `['==']` was not marked as invalid but now it is. So we have a **breaking change** here.

This als fixes the broken JSON-Schema for filters (https://github.com/geostyler/geostyler/issues/1400). 