### PR TITLE
Breaking: Updates WellKnownName and TypeGuards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 # misc
 npm-debug.log*
 *.log
+
+# dist
+dist

--- a/examples/sample.ts
+++ b/examples/sample.ts
@@ -29,7 +29,7 @@ const sampleStyle: Style = {
         spacing: 21,
         graphicStroke: {
           kind: 'Mark',
-          wellKnownName: 'Square'
+          wellKnownName: 'square'
         }
       }]
     },
@@ -68,7 +68,7 @@ const sampleStyle: Style = {
       },
       symbolizers: [{
         kind: 'Mark',
-        wellKnownName: 'Circle',
+        wellKnownName: 'circle',
         visibility: false,
         radius: 5
       }, {

--- a/index.d.ts
+++ b/index.d.ts
@@ -147,21 +147,23 @@ export interface BasePointSymbolizer extends BaseSymbolizer {
 }
 
 /**
+ * Template literal to be more precise on what a font specification of a wellknownname can look like.
+ * font-based symbols following Geotools/Geoserver syntax: ttf://<font name>#<hex code>
+ */
+export type FontSpec = `ttf://${string}#0x${string}`;
+
+/**
  * Supported WellKnownNames
  * Note that due to TypeScript limitations any string will be valid for this type; this will not change
  * until regexp or equivalent is supported, see:
  * https://github.com/microsoft/TypeScript/issues/6579
  *
- * Important: Geostyler Style Parsers are only expected to support the values listed below,
- * as well as font-based symbols following Geotools/Geoserver syntax:
- * ttf://<font name>#<hex code>
  */
-export type WellKnownName = 'Circle' | 'Square' | 'Triangle' | 'Star' | 'Cross' | 'X'
+export type WellKnownName = 'circle' | 'square' | 'triangle' | 'star' | 'cross' | 'x'
 | 'shape://vertline' | 'shape://horline' | 'shape://slash'
 | 'shape://backslash' | 'shape://dot' | 'shape://plus'
 | 'shape://times' | 'shape://oarrow' | 'shape://carrow'
-| 'ttf://Webdings#0x0064'
-| string;
+| FontSpec;
 
 /**
  * MarkSymbolizer describes the style representation of POINT data, if styled as

--- a/package.json
+++ b/package.json
@@ -5,16 +5,17 @@
   "main": "index.d.ts",
   "files": [
     "index.d.ts",
+    "dist/typeguards*",
     "examples/**",
     "schema.json",
-    "typeguards.ts",
     "README.md"
   ],
   "scripts": {
-    "lint": "eslint -c .eslintrc.js --ext .ts . && tsc --noEmit --project tsconfig.json",
+    "lint": "eslint -c .eslintrc.js --ext .ts . && tsc --noEmit",
+    "build": "tsc",
     "release": "np --no-yarn && git push upstream master",
     "generate-schema": "typescript-json-schema index.d.ts Style --id http://geostyler/geostyler-style.json > schema.json",
-    "prepublishOnly": "npm run generate-schema"
+    "prepublishOnly": "npm run build && npm run generate-schema"
   },
   "devDependencies": {
     "@terrestris/eslint-config-typescript": "^1.0.0",

--- a/schema.json
+++ b/schema.json
@@ -630,8 +630,35 @@
                     "type": "boolean"
                 },
                 "wellKnownName": {
-                    "description": "The WellKnownName of the MarkSymbolizer.",
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "enum": [
+                                "circle",
+                                "cross",
+                                "shape://backslash",
+                                "shape://carrow",
+                                "shape://dot",
+                                "shape://horline",
+                                "shape://oarrow",
+                                "shape://plus",
+                                "shape://slash",
+                                "shape://times",
+                                "shape://vertline",
+                                "square",
+                                "star",
+                                "triangle",
+                                "x"
+                            ],
+                            "type": "string"
+                        }
+                    ],
+                    "description": "The WellKnownName of the MarkSymbolizer."
                 }
             },
             "type": "object"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,9 @@
   "compilerOptions": {
     "baseUrl": ".",
     "module": "esnext",
+    "declaration": true,
     "esModuleInterop": true,
+    "outDir": "dist",
     "target": "es5",
     "lib": ["es6", "dom"],
     "sourceMap": true,


### PR DESCRIPTION
This PR updates the `WellKnownName` type and adds a transpilation for the TypeGuards.

1. Changes to `WellKnownName` are breaking as `'circle' | 'square' | 'triangle' | 'star' | 'cross' | 'x'` are now lower case and the newly inroduced `FontSpec` replaces the loose typization via `string`.
2. TypeGuards are now transpiled so they can be used in a regular ES-Setup without the need of transpiling the TypeGuards in a project.