### PR TITLE
Restructures code

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,2 @@
+export * from './style';
+export * from './typeguards';

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "geostyler-style",
   "version": "4.0.0",
   "description": "",
-  "main": "index.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
-    "index.d.ts",
-    "dist/typeguards*",
+    "dist/*",
     "examples/**",
     "schema.json",
     "README.md"

--- a/style.ts
+++ b/style.ts
@@ -105,7 +105,7 @@ export type SymbolizerKind = 'Fill' | 'Icon' | 'Line' | 'Text' | 'Mark' | 'Raste
 /**
  * A Symbolizer describes the style representation of geographical data.
  */
-interface BaseSymbolizer {
+export interface BaseSymbolizer {
   /**
    * Describes the type of the kind of the Symbolizer.
    */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,14 +19,8 @@
     "suppressImplicitAnyIndexErrors": true,
     "noUnusedLocals": true
   },
-  "exclude": [
-    "node_modules",
-    "build",
-    "scripts",
-    "dist",
-    "acceptance-tests",
-    "webpack",
-    "jest",
-    "src/setupTests.ts"
+  "files": [
+    "./typeguards.ts",
+    "./index.ts"
   ]
 }


### PR DESCRIPTION
This restructures the code.
It renames the `index.d.ts` to `style.d.ts` and introduces a `index.ts` which exports the style and the typeguards.

Therea are two reasons for this Change:
1. The exported TypeGuards have been broken as `typeguards.ts` directly imported from the `index.d.ts`, and `.d.ts` files are not considerd during build: https://github.com/Microsoft/TypeScript/issues/5112#issuecomment-146365399
2. The `types` field in the `package.json` doesn't allow an array so all the declarations of the package should live in one file. Another benefit is that you can now import the TypeGuards directly. e.G: `import isCombinationFilter from 'geostyler-style'`

