### PR TITLE
Set module type to commonjs

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "module": "esnext",
+    "module": "commonjs",
     "declaration": true,
     "esModuleInterop": true,
     "outDir": "dist",


### PR DESCRIPTION
This sets the module system to `commonjs`. The previous setting was exporting the distribution files in `esnext` syntax which requires an appropriate module resolution (for `import`/`export`) in the target application. If this is not available, e.g. in the [geostyler-cli](https://github.com/geostyler/geostyler-cli), application startup might fail with errors like `SyntaxError: Unexpected token 'export'`.