### PR TITLE
Introduces complex parser output

### DIFF
--- a/style.ts
+++ b/style.ts
@@ -685,9 +685,53 @@ export type SupportInfo = {
 export type SupportDef = SupportInfo | SupportLevel;
 
 /**
+ * The Result of the readStyle function of a StyleParser.
+ */
+export type ReadStyleResult = {
+  /**
+   * A list of warnings occured while reading the stlye.
+   */
+  warnings?: String[];
+  /**
+   * A list of unsupportedProperties used while reading the stlye.
+   */
+  unsupportedProperties?: UnsupportedProperties;
+  /**
+   * The geostyler-style as read by the parser.
+   */
+  output?: Style;
+  /**
+   * A list of errors occured while reading the stlye.
+   */
+  errors?: Error[];
+};
+
+/**
+ * The Result of the writeStyle function of a StyleParser.
+ */
+export type WriteStyleResult<T = any> = {
+  /**
+   * A list of warnings occured while reading the stlye.
+   */
+  warnings?: String[];
+  /**
+   * A list of unsupportedProperties used while reading the stlye.
+   */
+  unsupportedProperties?: UnsupportedProperties;
+  /**
+   * The target-style as written by the parser.
+   */
+  output?: T;
+  /**
+   * A list of errors occured while reading the stlye.
+   */
+  errors?: Error[];
+};
+
+/**
  * Interface, which has to be implemented by all GeoStyler style parser classes.
  */
-export interface StyleParser {
+export interface StyleParser<T = any> {
   /**
    * The name of the Parser
    */
@@ -703,7 +747,7 @@ export interface StyleParser {
    *
    * @param inputStyle
    */
-  readStyle(inputStyle: any): Promise<Style>;
+  readStyle(inputStyle: T): Promise<ReadStyleResult>;
 
   /**
    * Reads the GeoStyler Style and transforms it to the target Style
@@ -711,7 +755,7 @@ export interface StyleParser {
    *
    * @param geoStylerStyle Style
    */
-  writeStyle(geoStylerStyle: Style): Promise<any>;
+  writeStyle(geoStylerStyle: Style): Promise<WriteStyleResult<T>>;
 
   /**
    * Parses an input Rule and transforms it to a GeoStyler Rule

--- a/style.ts
+++ b/style.ts
@@ -691,9 +691,9 @@ export type ReadStyleResult = {
   /**
    * A list of warnings occured while reading the stlye.
    */
-  warnings?: String[];
+  warnings?: string[];
   /**
-   * A list of unsupportedProperties used while reading the stlye.
+   * A list of unsupportedProperties used while reading the style.
    */
   unsupportedProperties?: UnsupportedProperties;
   /**
@@ -701,7 +701,7 @@ export type ReadStyleResult = {
    */
   output?: Style;
   /**
-   * A list of errors occured while reading the stlye.
+   * A list of errors occured while reading the style.
    */
   errors?: Error[];
 };
@@ -711,11 +711,11 @@ export type ReadStyleResult = {
  */
 export type WriteStyleResult<T = any> = {
   /**
-   * A list of warnings occured while reading the stlye.
+   * A list of warnings occured while writing the style.
    */
-  warnings?: String[];
+  warnings?: string[];
   /**
-   * A list of unsupportedProperties used while reading the stlye.
+   * A list of unsupportedProperties used while writing the style.
    */
   unsupportedProperties?: UnsupportedProperties;
   /**
@@ -723,7 +723,7 @@ export type WriteStyleResult<T = any> = {
    */
   output?: T;
   /**
-   * A list of errors occured while reading the stlye.
+   * A list of errors occured while writing the style.
    */
   errors?: Error[];
 };


### PR DESCRIPTION
# BREAKING CHANGE :exclamation: 


This introduces the complex parser output as discussed in https://github.com/geostyler/geostyler/issues/286.
This will be needed to enhance feedback when parsing to solve issues like: https://github.com/geostyler/geostyler/issues/1485

It also adds an optional generic to the StyleParser to enhance typing when working with `readStyle` and `writeStyle`.

To see an possible implementation have a look at: https://github.com/geostyler/geostyler-sld-parser/pull/414