### PR TITLE
Introduce RangeFilter and the corresponding operator "<=x<="

### DIFF
--- a/examples/parsersample.ts
+++ b/examples/parsersample.ts
@@ -1,4 +1,5 @@
-import { Style, StyleParser, UnsupportedProperties } from 'index';
+import { Style, StyleParser, UnsupportedProperties } from '../index';
+import { ReadStyleResult, WriteStyleResult } from '../style';
 
 export class SampleParser implements StyleParser {
 
@@ -20,15 +21,21 @@ export class SampleParser implements StyleParser {
 
   title = 'Sample Parser';
 
-  writeStyle(geoStylerStyle: Style): Promise<string> {
-    return new Promise<string>(() => 'sample');
+  writeStyle(geoStylerStyle: Style): Promise<WriteStyleResult> {
+    return new Promise<WriteStyleResult>(() => {
+      return {
+        output: 'sample'
+      };
+    });
   }
 
-  readStyle(sldString: string): Promise<Style> {
-    return new Promise<Style>(() => {
+  readStyle(sldString: string): Promise<ReadStyleResult> {
+    return new Promise<ReadStyleResult>(() => {
       return {
-        name: 'Samplestyle',
-        rules: []
+        output: {
+          name: 'Samplestyle',
+          rules: []
+        }
       };
     });
   }

--- a/examples/rastersample.ts
+++ b/examples/rastersample.ts
@@ -1,4 +1,4 @@
-import { Style } from 'index';
+import { Style } from '../index';
 
 const sampleRasterStyle: Style = {
   name: 'Sample Raster Style',

--- a/examples/sample.ts
+++ b/examples/sample.ts
@@ -8,7 +8,7 @@ const sampleStyle: Style = {
       filter: ['&&',
         ['==', 'name', 'Peter'],
         ['<=', 'age', 12],
-        ['<x<', 'height', 1, 2]
+        ['<=x<=', 'height', 1, 2]
       ],
       scaleDenominator: {
         min: 500,

--- a/examples/sample.ts
+++ b/examples/sample.ts
@@ -1,4 +1,4 @@
-import { Style } from 'index';
+import { Style } from '../index';
 
 const sampleStyle: Style = {
   name: 'Sample Point Style',
@@ -7,7 +7,8 @@ const sampleStyle: Style = {
       name: 'Young Peter',
       filter: ['&&',
         ['==', 'name', 'Peter'],
-        ['<=', 'age', 12]
+        ['<=', 'age', 12],
+        ['<x<', 'height', 1, 2]
       ],
       scaleDenominator: {
         min: 500,

--- a/style.ts
+++ b/style.ts
@@ -31,7 +31,7 @@ export type PropertyValue = string | number | boolean | null;
 /**
  * The possible Operators used for comparison Filters.
  */
-export type ComparisonOperator = '==' | '*=' | '!=' | '<' | '<=' | '>' | '>=';
+export type ComparisonOperator = '==' | '*=' | '!=' | '<' | '<=' | '>' | '>=' | '<x<';
 
 /**
  * The possible Operators used for combination Filters.
@@ -70,6 +70,11 @@ export type StrMatchesFunctionFilter = [
 export type FunctionFilter = StrMatchesFunctionFilter;
 
 /**
+ * A Filter that checks if a property value is between to values.
+ */
+export type BetweenFilter = ['<x<', PropertyName | FunctionFilter, number, number];
+
+/**
  * A ComparisonFilter compares a value of an object (by key) with an expected
  * value.
  */
@@ -77,7 +82,7 @@ export type ComparisonFilter = [
   ComparisonOperator,
   PropertyName | FunctionFilter,
   PropertyValue
-];
+] | BetweenFilter;
 
 /**
  * A CombinationFilter combines N Filters with a logical OR / AND operator.

--- a/style.ts
+++ b/style.ts
@@ -31,7 +31,7 @@ export type PropertyValue = string | number | boolean | null;
 /**
  * The possible Operators used for comparison Filters.
  */
-export type ComparisonOperator = '==' | '*=' | '!=' | '<' | '<=' | '>' | '>=' | '<x<';
+export type ComparisonOperator = '==' | '*=' | '!=' | '<' | '<=' | '>' | '>=' | '<=x<=';
 
 /**
  * The possible Operators used for combination Filters.
@@ -70,9 +70,9 @@ export type StrMatchesFunctionFilter = [
 export type FunctionFilter = StrMatchesFunctionFilter;
 
 /**
- * A Filter that checks if a property value is between to values.
+ * A Filter that checks if a property is in a range of two values (inclusive).
  */
-export type BetweenFilter = ['<x<', PropertyName | FunctionFilter, number, number];
+export type RangeFilter = ['<=x<=', PropertyName | FunctionFilter, number, number];
 
 /**
  * A ComparisonFilter compares a value of an object (by key) with an expected
@@ -82,7 +82,7 @@ export type ComparisonFilter = [
   ComparisonOperator,
   PropertyName | FunctionFilter,
   PropertyValue
-] | BetweenFilter;
+] | RangeFilter;
 
 /**
  * A CombinationFilter combines N Filters with a logical OR / AND operator.

--- a/typeguards.ts
+++ b/typeguards.ts
@@ -52,7 +52,7 @@ export const isOperator = (got: any): got is Operator => {
     isNegationOperator(got);
 };
 export const isComparisonOperator = (got: any): got is ComparisonOperator => {
-  return ['==', '*=' , '!=' , '<' , '<=' , '>' , '>=', '<x<'].includes(got);
+  return ['==', '*=' , '!=' , '<' , '<=' , '>' , '>=', '<=x<='].includes(got);
 };
 export const isCombinationOperator = (got: any): got is CombinationOperator => {
   return ['&&', '||'].includes(got);
@@ -72,13 +72,13 @@ export const isFilter = (got: any): got is Filter => {
     isNegationFilter(got);
 };
 export const isComparisonFilter = (got: any): got is ComparisonFilter => {
-  const expectedLength = got[0] === '<x<' ? 4 : 3;
+  const expectedLength = got[0] === '<=x<=' ? 4 : 3;
   return Array.isArray(got) &&
     got.length === expectedLength &&
     isComparisonOperator(got[0]) &&
     (isFunctionFilter(got[1]) || _isString(got[1])) &&
     isPropertyValue(got[2]) &&
-    (got[0] !== '<x<' || _isNumber(got[3]));
+    (got[0] !== '<=x<=' || _isNumber(got[3]));
 };
 export const isCombinationFilter = (got: any): got is CombinationFilter => {
   return Array.isArray(got) &&

--- a/typeguards.ts
+++ b/typeguards.ts
@@ -52,7 +52,7 @@ export const isOperator = (got: any): got is Operator => {
     isNegationOperator(got);
 };
 export const isComparisonOperator = (got: any): got is ComparisonOperator => {
-  return ['==', '*=' , '!=' , '<' , '<=' , '>' , '>='].includes(got);
+  return ['==', '*=' , '!=' , '<' , '<=' , '>' , '>=', '<x<'].includes(got);
 };
 export const isCombinationOperator = (got: any): got is CombinationOperator => {
   return ['&&', '||'].includes(got);
@@ -72,11 +72,13 @@ export const isFilter = (got: any): got is Filter => {
     isNegationFilter(got);
 };
 export const isComparisonFilter = (got: any): got is ComparisonFilter => {
+  const expectedLength = got[0] === '<x<' ? 4 : 3;
   return Array.isArray(got) &&
-    got.length === 3 &&
+    got.length === expectedLength &&
     isComparisonOperator(got[0]) &&
     (isFunctionFilter(got[1]) || _isString(got[1])) &&
-    isPropertyValue(got[2]);
+    isPropertyValue(got[2]) &&
+    (got[0] !== '<x<' || _isNumber(got[3]));
 };
 export const isCombinationFilter = (got: any): got is CombinationFilter => {
   return Array.isArray(got) &&


### PR DESCRIPTION
This adds support for a ~~between filter~~ range filter which allows to check if a numeric property value is between to other values (within a range). e.g.: 

```ts
// Filter all cities with a population between 5.000 and 25.000:
const filter = ['<=x<=', 'population', 5000, 25000];
```

targets https://github.com/geostyler/geostyler/issues/87

It also fixes the samples.