### PR TITLE
Introduces "format" property for the IconSymbolizer

### DIFF
--- a/examples/sample.ts
+++ b/examples/sample.ts
@@ -19,7 +19,9 @@ const sampleStyle: Style = {
         visibility: false,
         allowOverlap: true,
         optional: false,
-        rotationAlignment: 'map'
+        rotationAlignment: 'map',
+        image: 'http://myserver/getImage',
+        format: 'image/png'
       }, {
         kind: 'Line',
         blur: 3,
@@ -95,7 +97,8 @@ const sampleStyle: Style = {
         kind: 'Fill',
         color: '#FF0000',
         graphicFill: {
-          kind: 'Icon'
+          kind: 'Icon',
+          image: '/myimage.png'
         }
       }, {
         kind: 'Raster',

--- a/schema.json
+++ b/schema.json
@@ -191,7 +191,53 @@
                     "type": "array"
                 },
                 {
-                    "description": "A ComparisonFilter compares a value of an object (by key) with an expected\nvalue.",
+                    "description": "A Filter that checks if a property is in a range of two values (inclusive).",
+                    "items": [
+                        {
+                            "enum": [
+                                "<=x<="
+                            ],
+                            "type": "string"
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "description": "A FunctionFilter that expects a string (propertyName) as second argument and\na regular expression as third argument. An actual parser implementation has to\nreturn a value for this function expression.",
+                                    "items": [
+                                        {
+                                            "enum": [
+                                                "FN_strMatches"
+                                            ],
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/RegExp"
+                                        }
+                                    ],
+                                    "maxItems": 3,
+                                    "minItems": 3,
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ],
+                    "maxItems": 4,
+                    "minItems": 4,
+                    "type": "array"
+                },
+                {
                     "items": [
                         {
                             "description": "The possible Operators used for comparison Filters.",
@@ -200,6 +246,7 @@
                                 "*=",
                                 "<",
                                 "<=",
+                                "<=x<=",
                                 "==",
                                 ">",
                                 ">="
@@ -306,6 +353,17 @@
                 },
                 "color": {
                     "description": "A color defined as a hex-color string.",
+                    "type": "string"
+                },
+                "format": {
+                    "description": "An optional configuration for the image format as MIME type.\nThis might be needed if the image(path) has no filending specified. e.g. http://myserver/getImage",
+                    "enum": [
+                        "image/gif",
+                        "image/jpeg",
+                        "image/jpg",
+                        "image/png",
+                        "image/svg+xml"
+                    ],
                     "type": "string"
                 },
                 "haloBlur": {
@@ -881,7 +939,53 @@
                             "type": "array"
                         },
                         {
-                            "description": "A ComparisonFilter compares a value of an object (by key) with an expected\nvalue.",
+                            "description": "A Filter that checks if a property is in a range of two values (inclusive).",
+                            "items": [
+                                {
+                                    "enum": [
+                                        "<=x<="
+                                    ],
+                                    "type": "string"
+                                },
+                                {
+                                    "anyOf": [
+                                        {
+                                            "description": "A FunctionFilter that expects a string (propertyName) as second argument and\na regular expression as third argument. An actual parser implementation has to\nreturn a value for this function expression.",
+                                            "items": [
+                                                {
+                                                    "enum": [
+                                                        "FN_strMatches"
+                                                    ],
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/RegExp"
+                                                }
+                                            ],
+                                            "maxItems": 3,
+                                            "minItems": 3,
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ],
+                            "maxItems": 4,
+                            "minItems": 4,
+                            "type": "array"
+                        },
+                        {
                             "items": [
                                 {
                                     "description": "The possible Operators used for comparison Filters.",
@@ -890,6 +994,7 @@
                                         "*=",
                                         "<",
                                         "<=",
+                                        "<=x<=",
                                         "==",
                                         ">",
                                         ">="

--- a/style.ts
+++ b/style.ts
@@ -399,6 +399,11 @@ export interface IconSymbolizer extends BasePointSymbolizer {
    */
   image?: string;
   /**
+   * An optional configuration for the image format as MIME type.
+   * This might be needed if the image(path) has no filending specified. e.g. http://myserver/getImage
+   */
+  format?: `image/${'png' | 'jpg' | 'jpeg' | 'gif' | 'svg+xml'}`;
+  /**
    * If true, the icon will be kept upright.
    */
   keepUpright?: boolean;


### PR DESCRIPTION
This introduces the `format` property for the `IconSybmolizer` like @dsuren1 introduced it to this [fork](https://github.com/geosolutions-it/geostyler-style/pull/1).

It also updates the schema.json.

Solves https://github.com/geostyler/geostyler/issues/1453