### PR TITLE
Fix missing source file warnings

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "target": "es5",
     "lib": ["es6", "dom"],
     "sourceMap": true,
+    "inlineSources": true,
     "allowJs": false,
     "moduleResolution": "node",
     "rootDir": ".",


### PR DESCRIPTION
Fixes some annoying warnings when building an app that uses this project as an npm package.

```
WARNING in ./node_modules/geostyler-openlayers-parser/node_modules/geostyler-style/dist/typeguards.js
Module Warning (from ./node_modules/source-map-loader/index.js):
(Emitted value instead of an instance of Error) Cannot find source file '../typeguards.ts': Error: Can't resolve '../typeguards.ts'
```

The build currently produces a `typeguards.js.map` file that references a `../typeguard.ts` file. This throws an error because the  .ts files aren't actually included in the final version that gets published to npm. I included them inline here, but another option is to include the actual source files too. Either works. This same issue applies to all of the geostyler/* repos. I just wanted to post one PR first to get feedback on this change.