### PR TITLE
Strict typing for functions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,7 @@ module.exports = {
   extends: '@terrestris/eslint-config-typescript',
   rules: {
     camelcase: [
-      "off",
+      'off',
       {
         ignoreImports: true
       }

--- a/examples/expressions.ts
+++ b/examples/expressions.ts
@@ -4,19 +4,23 @@ const sampleExpressionStyle: Style = {
   name: 'Sample style using expressions',
   rules: [
     {
-      name: 'Very old Peter',
+      name: 'The max of Pi ',
       symbolizers: [{
         kind: 'Text',
         lineHeight: {
-          type: 'numberfunction',
-          name: 'strLength',
-          args: [
-            {
-              type: 'stringfunction',
+          name: 'max',
+          args: [{
+            name: 'strLength',
+            args: [{
               name: 'strConcat',
-              args: ['pre', 'name']
-            }
-          ]
+              args: ['pr', {
+                name: 'property',
+                args: ['Hilde']
+              }]
+            }]
+          }, {
+            name: 'pi'
+          }]
         }
       }]
     }

--- a/examples/expressions.ts
+++ b/examples/expressions.ts
@@ -6,24 +6,17 @@ const sampleExpressionStyle: Style = {
     {
       name: 'Very old Peter',
       symbolizers: [{
-        kind: 'Line',
-        width: {
-          type: 'functioncall',
-          name: 'peter',
-          args: [{
-            type: 'literal',
-            value: 7
-          }, {
-            type: 'property',
-            name: 'myProp'
-          }, {
-            type: 'functioncall',
-            name: 'hans',
-            args: [{
-              type: 'literal',
-              value: 12
-            }]
-          }]
+        kind: 'Text',
+        lineHeight: {
+          type: 'numberfunction',
+          name: 'strLength',
+          args: [
+            {
+              type: 'stringfunction',
+              name: 'strConcat',
+              args: ['pre', 'name']
+            }
+          ]
         }
       }]
     }

--- a/examples/sample.ts
+++ b/examples/sample.ts
@@ -39,7 +39,17 @@ const sampleStyle: Style = {
     {
       name: 'Twelve year old Peter',
       filter: ['&&',
-        ['==', ['FN_strMatches', 'name', /Peter/], true],
+        {
+          type: 'booleanfunction',
+          name: 'strMatches',
+          args: [
+            {
+              type: 'property',
+              name: 'name'
+            },
+            'Peter'
+          ]
+        },
         ['==', 'age', 12]
       ],
       scaleDenominator: {

--- a/examples/sample.ts
+++ b/examples/sample.ts
@@ -39,16 +39,19 @@ const sampleStyle: Style = {
     {
       name: 'Twelve year old Peter',
       filter: ['&&',
-        {
-          name: 'strMatches',
-          args: [
-            {
-              name: 'property',
-              args: ['name']
-            },
-            'Peter'
-          ]
-        },
+        ['==',
+          {
+            name: 'strMatches',
+            args: [
+              {
+                name: 'property',
+                args: ['name']
+              },
+              'Peter'
+            ]
+          },
+          true
+        ],
         ['==', 'age', 12]
       ],
       scaleDenominator: {

--- a/examples/sample.ts
+++ b/examples/sample.ts
@@ -40,12 +40,11 @@ const sampleStyle: Style = {
       name: 'Twelve year old Peter',
       filter: ['&&',
         {
-          type: 'booleanfunction',
           name: 'strMatches',
           args: [
             {
-              type: 'property',
-              name: 'name'
+              name: 'property',
+              args: ['name']
             },
             'Peter'
           ]

--- a/examples/typeguardsample.ts
+++ b/examples/typeguardsample.ts
@@ -4,8 +4,7 @@ import {
   isComparisonOperator,
   isFilter,
   isNegationOperator,
-  isOperator,
-  isStrMatchesFunctionOperator
+  isOperator
 } from '../typeguards';
 
 /*
@@ -44,7 +43,4 @@ if (isCombinationOperator(combinationOperator)) {
 }
 if (isNegationOperator(negationOperator)) {
   console.log(`${negationOperator} is a NegationOperator`);
-}
-if (isStrMatchesFunctionOperator(strMatchesFunctionOperator)) {
-  console.log(`${strMatchesFunctionOperator} is a StrMatchesFunctionOperator`);
 }

--- a/functions.ts
+++ b/functions.ts
@@ -6,9 +6,11 @@ import {
 
 export type GeoStylerFunction = GeoStylerNumberFunction |
   GeoStylerStringFunction |
-  GeoStylerBooleanFunction;
+  GeoStylerBooleanFunction |
+  GeoStylerUnknownFunction;
 
-export type GeoStylerNumberFunction = Fabs |
+export type GeoStylerNumberFunction = GeoStylerUnknownFunction |
+Fabs |
 Facos |
 Fasin |
 Fatan |
@@ -35,8 +37,8 @@ Ftan |
 FtoDegrees |
 FtoRadians;
 
-export type GeoStylerStringFunction = FnumberFormat |
-Fproperty |
+export type GeoStylerStringFunction = GeoStylerUnknownFunction |
+FnumberFormat |
 FstrAbbreviate |
 FstrCapitalize |
 FstrConcat |
@@ -49,7 +51,8 @@ FstrToLowerCase |
 FstrToUpperCase |
 FstrTrim;
 
-export type GeoStylerBooleanFunction = Fbetween |
+export type GeoStylerBooleanFunction = GeoStylerUnknownFunction |
+Fbetween |
 Fdouble2bool |
 Fin |
 FparseBoolean |
@@ -57,6 +60,8 @@ FstrEndsWith |
 FstrEqualsIgnoreCase |
 FstrMatches |
 FstrStartsWith;
+
+export type GeoStylerUnknownFunction = Fproperty;
 
 /**
  * The absolute value of the specified number value
@@ -244,7 +249,7 @@ export interface FparseBoolean extends FunctionCall<boolean> {
 /**
  * Returns an approximation of pi, the ratio of the circumference of a circle to its diameter
  */
-export interface Fpi extends FunctionCall<number> {
+export interface Fpi extends Omit<FunctionCall<number>, 'args'> {
   name: 'pi';
 };
 
@@ -263,7 +268,7 @@ export interface Fpow extends FunctionCall<number> {
  * Returns the value of the property propertyName. Allows property names to be compute
  * or specified by Variable substitution in SLD.
  */
-export interface Fproperty extends FunctionCall<string> {
+export interface Fproperty extends FunctionCall<unknown> {
   name: 'property';
   args: [
     Expression<string>
@@ -273,7 +278,7 @@ export interface Fproperty extends FunctionCall<string> {
 /**
  * Returns a Double value with a positive sign, greater than or equal to 0.0 and less than 1.0.
  */
-export interface Frandom extends FunctionCall<number> {
+export interface Frandom extends Omit<FunctionCall<number>, 'args'> {
   name: 'random';
 };
 

--- a/functions.ts
+++ b/functions.ts
@@ -3,6 +3,7 @@ import {
   FunctionCall,
   Expression
 } from './style';
+
 export type GeoStylerNumberFunction = Fabs |
 Fabs_2 |
 Fabs_3 |

--- a/functions.ts
+++ b/functions.ts
@@ -5,49 +5,25 @@ import {
 } from './style';
 
 export type GeoStylerNumberFunction = Fabs |
-Fabs_2 |
-Fabs_3 |
-Fabs_4 |
 Facos |
 Fasin |
 Fatan |
 Fatan2 |
 Fceil |
 Fcos |
-Fdisjoint3D |
-Fdistance |
-Fdistance3D |
-FendAngle |
 Fexp |
 Ffloor |
-Fint2ddouble |
-Fintersects3D |
-FisWithinDistance3D |
-Flength |
 Flog |
 Fmax |
-Fmax_2 |
-Fmax_3 |
-Fmax_4 |
 Fmin |
-Fmin_2 |
-Fmin_3 |
-Fmin_4 |
 Fmodulo |
-FparseDouble |
-FparseInt |
-FparseLong |
 Fpi |
 Fpow |
 Frandom |
 Frint |
 Fround |
-Fround_2 |
-FroundDouble |
 Fsin |
-Fsize |
 Fsqrt |
-FstartAngle |
 FstrIndexOf |
 FstrLastIndexOf |
 FstrLength |
@@ -55,99 +31,35 @@ Ftan |
 FtoDegrees |
 FtoRadians;
 
-export type GeoStylerStringFunction = Farray |
-FattributeCount |
-FboundedBy |
-Fclassify |
-Fcontrast |
-Fconvert |
-Fdarken |
-Fdesaturate |
-Fdifference |
-FendPoint |
-Fenv |
-Fgrayscale |
-Fhsl |
-Fid |
-Fif_then_else |
-Fintersection |
-FjsonPointer |
-Flapply |
-Flighten |
-Flist |
-FlistMultiply |
-Flitem |
-Fliterate |
-FmapGet |
-Fmix |
-FnumberFormat |
-FnumberFormat2 |
-Foverlaps |
-Fparameter |
+export type GeoStylerStringFunction = FnumberFormat |
 Fproperty |
-Frelate |
-FrescaleToPixels |
-Fsaturate |
-Fshade |
-Fspin |
-FstartPoint |
 FstrAbbreviate |
 FstrCapitalize |
 FstrConcat |
 FstrDefaultIfBlank |
-FstringTemplate |
-FstrPosition |
 FstrReplace |
 FstrStripAccents |
 FstrSubstring |
 FstrSubstringStart |
 FstrToLowerCase |
 FstrToUpperCase |
-FstrTrim |
-FstrTrim2 |
-FstrURLEncode |
-Ftint;
+FstrTrim;
 
 export type GeoStylerBooleanFunction = Fbetween |
-Fcontains |
-Fcrosses |
-Fdisjoint |
 Fdouble2bool |
-FequalsExact |
-FequalsExactTolerance |
-FequalTo |
-FgreaterEqualThan |
-FgreaterThan |
 Fin |
-Fin10 |
-Fin2 |
-Fin3 |
-Fin4 |
-Fin5 |
-Fin6 |
-Fin7 |
-Fin8 |
-Fin9 |
-FinArray |
-Fint2bbool |
-Fintersects |
-FisCached |
-FisCoverage |
-FisInstanceOf |
-FisLike |
-FisNull |
-FisWithinDistance |
-FlessEqualThan |
-FlessThan |
-Fnot |
-FnotEqualTo |
 FparseBoolean |
 FstrEndsWith |
 FstrEqualsIgnoreCase |
 FstrMatches |
 FstrStartsWith;
 
-export interface Fabs extends FunctionCall {
+export type GeoStylerVoidFunction = unknown;
+
+/**
+ * The absolute value of the specified number value
+ */
+export interface Fabs extends FunctionCall<number> {
   type: 'numberfunction';
   name: 'abs';
   args: [
@@ -155,31 +67,10 @@ export interface Fabs extends FunctionCall {
   ];
 };
 
-export interface Fabs_2 extends FunctionCall {
-  type: 'numberfunction';
-  name: 'abs_2';
-  args: [
-    Expression<number>
-  ];
-};
-
-export interface Fabs_3 extends FunctionCall {
-  type: 'numberfunction';
-  name: 'abs_3';
-  args: [
-    Expression<number>
-  ];
-};
-
-export interface Fabs_4 extends FunctionCall {
-  type: 'numberfunction';
-  name: 'abs_4';
-  args: [
-    Expression<number>
-  ];
-};
-
-export interface Facos extends FunctionCall {
+/**
+ * Returns the arc cosine of an angle in radians, in the range of 0.0 through PI
+ */
+export interface Facos extends FunctionCall<number> {
   type: 'numberfunction';
   name: 'acos';
   args: [
@@ -187,12 +78,10 @@ export interface Facos extends FunctionCall {
   ];
 };
 
-export interface Farray extends FunctionCall {
-  type: 'stringfunction';
-  name: 'array';
-};
-
-export interface Fasin extends FunctionCall {
+/**
+ * Returns the arc sine of an angle in radians, in the range of -PI / 2 through PI / 2
+ */
+export interface Fasin extends FunctionCall<number> {
   type: 'numberfunction';
   name: 'asin';
   args: [
@@ -200,7 +89,10 @@ export interface Fasin extends FunctionCall {
   ];
 };
 
-export interface Fatan extends FunctionCall {
+/**
+ * Returns the arc tangent of an angle in radians, in the range of -PI/2 through PI/2
+ */
+export interface Fatan extends FunctionCall<number> {
   type: 'numberfunction';
   name: 'atan';
   args: [
@@ -208,7 +100,10 @@ export interface Fatan extends FunctionCall {
   ];
 };
 
-export interface Fatan2 extends FunctionCall {
+/**
+ * Converts a rectangular coordinate (x, y) to polar (r, theta) and returns theta.
+ */
+export interface Fatan2 extends FunctionCall<number> {
   type: 'numberfunction';
   name: 'atan2';
   args: [
@@ -217,15 +112,10 @@ export interface Fatan2 extends FunctionCall {
   ];
 };
 
-export interface FattributeCount extends FunctionCall {
-  type: 'stringfunction';
-  name: 'attributeCount';
-  args: [
-    Expression<string>
-  ];
-};
-
-export interface Fbetween extends FunctionCall {
+/**
+ * Returns true if arg1 <= arg0 <= arg2
+ */
+export interface Fbetween extends FunctionCall<boolean> {
   type: 'booleanfunction';
   name: 'between';
   args: [
@@ -235,12 +125,11 @@ export interface Fbetween extends FunctionCall {
   ];
 };
 
-export interface FboundedBy extends FunctionCall {
-  type: 'stringfunction';
-  name: 'boundedBy';
-};
-
-export interface Fceil extends FunctionCall {
+/**
+ * Returns the smallest (closest to negative infinity) number value that is greater than or equal to
+ * x and is equal to a mathematical integer.
+ */
+export interface Fceil extends FunctionCall<number> {
   type: 'numberfunction';
   name: 'ceil';
   args: [
@@ -248,45 +137,10 @@ export interface Fceil extends FunctionCall {
   ];
 };
 
-export interface Fclassify extends FunctionCall {
-  type: 'stringfunction';
-  name: 'classify';
-  args: [
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface Fcontains extends FunctionCall {
-  type: 'booleanfunction';
-  name: 'contains';
-  args: [
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface Fcontrast extends FunctionCall {
-  type: 'stringfunction';
-  name: 'contrast';
-  args: [
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<number>
-  ];
-};
-
-export interface Fconvert extends FunctionCall {
-  type: 'stringfunction';
-  name: 'convert';
-  args: [
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface Fcos extends FunctionCall {
+/**
+ * Returns the cosine of an angle expressed in radians
+ */
+export interface Fcos extends FunctionCall<number> {
   type: 'numberfunction';
   name: 'cos';
   args: [
@@ -294,81 +148,10 @@ export interface Fcos extends FunctionCall {
   ];
 };
 
-export interface Fcrosses extends FunctionCall {
-  type: 'booleanfunction';
-  name: 'crosses';
-  args: [
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface Fdarken extends FunctionCall {
-  type: 'stringfunction';
-  name: 'darken';
-  args: [
-    Expression<string>,
-    Expression<number>,
-    Expression<string>
-  ];
-};
-
-export interface Fdesaturate extends FunctionCall {
-  type: 'stringfunction';
-  name: 'desaturate';
-  args: [
-    Expression<string>,
-    Expression<number>,
-    Expression<string>
-  ];
-};
-
-export interface Fdifference extends FunctionCall {
-  type: 'stringfunction';
-  name: 'difference';
-  args: [
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface Fdisjoint extends FunctionCall {
-  type: 'booleanfunction';
-  name: 'disjoint';
-  args: [
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface Fdisjoint3D extends FunctionCall {
-  type: 'numberfunction';
-  name: 'disjoint3D';
-  args: [
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface Fdistance extends FunctionCall {
-  type: 'numberfunction';
-  name: 'distance';
-  args: [
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface Fdistance3D extends FunctionCall {
-  type: 'numberfunction';
-  name: 'distance3D';
-  args: [
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface Fdouble2bool extends FunctionCall {
+/**
+ * Returns true if x is zero, false otherwise
+ */
+export interface Fdouble2bool extends FunctionCall<boolean> {
   type: 'booleanfunction';
   name: 'double2bool';
   args: [
@@ -376,60 +159,10 @@ export interface Fdouble2bool extends FunctionCall {
   ];
 };
 
-export interface FendAngle extends FunctionCall {
-  type: 'numberfunction';
-  name: 'endAngle';
-  args: [
-    Expression<string>
-  ];
-};
-
-export interface FendPoint extends FunctionCall {
-  type: 'stringfunction';
-  name: 'endPoint';
-  args: [
-    Expression<string>
-  ];
-};
-
-export interface Fenv extends FunctionCall {
-  type: 'stringfunction';
-  name: 'env';
-  args: [
-    Expression<string>
-  ];
-};
-
-export interface FequalsExact extends FunctionCall {
-  type: 'booleanfunction';
-  name: 'equalsExact';
-  args: [
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface FequalsExactTolerance extends FunctionCall {
-  type: 'booleanfunction';
-  name: 'equalsExactTolerance';
-  args: [
-    Expression<string>,
-    Expression<string>,
-    Expression<number>
-  ];
-};
-
-export interface FequalTo extends FunctionCall {
-  type: 'booleanfunction';
-  name: 'equalTo';
-  args: [
-    Expression<string>,
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface Fexp extends FunctionCall {
+/**
+ * Returns Euler’s number e raised to the power of x
+ */
+export interface Fexp extends FunctionCall<number> {
   type: 'numberfunction';
   name: 'exp';
   args: [
@@ -437,7 +170,11 @@ export interface Fexp extends FunctionCall {
   ];
 };
 
-export interface Ffloor extends FunctionCall {
+/**
+ * Returns the largest (closest to positive infinity) value that is less than or equal to x and is
+ * equal to a mathematical integer
+ */
+export interface Ffloor extends FunctionCall<number> {
   type: 'numberfunction';
   name: 'floor';
   args: [
@@ -445,393 +182,20 @@ export interface Ffloor extends FunctionCall {
   ];
 };
 
-export interface Fgrayscale extends FunctionCall {
-  type: 'stringfunction';
-  name: 'grayscale';
-  args: [
-    Expression<string>
-  ];
-};
-
-export interface FgreaterEqualThan extends FunctionCall {
-  type: 'booleanfunction';
-  name: 'greaterEqualThan';
-  args: [
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface FgreaterThan extends FunctionCall {
-  type: 'booleanfunction';
-  name: 'greaterThan';
-  args: [
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface Fhsl extends FunctionCall {
-  type: 'stringfunction';
-  name: 'hsl';
-  args: [
-    Expression<number>,
-    Expression<number>,
-    Expression<number>
-  ];
-};
-
-export interface Fid extends FunctionCall {
-  type: 'stringfunction';
-  name: 'id';
-};
-
-export interface Fif_then_else extends FunctionCall {
-  type: 'stringfunction';
-  name: 'if_then_else';
-  args: [
-    Expression<boolean>,
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface Fin extends FunctionCall {
+/**
+ * Returns true if arguments[0] is equal to one of the arguments[1], …, arguments[n] values. Use the
+ * function name matching the number of arguments specified.
+ */
+export interface Fin extends FunctionCall<boolean> {
   type: 'booleanfunction';
   name: 'in';
-  args: [
-    Expression<string>,
-    Expression<string>
-  ];
+  args: Expression<string>[];
 };
 
-export interface Fin10 extends FunctionCall {
-  type: 'booleanfunction';
-  name: 'in10';
-  args: [
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface Fin2 extends FunctionCall {
-  type: 'booleanfunction';
-  name: 'in2';
-  args: [
-    Expression<string>,
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface Fin3 extends FunctionCall {
-  type: 'booleanfunction';
-  name: 'in3';
-  args: [
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface Fin4 extends FunctionCall {
-  type: 'booleanfunction';
-  name: 'in4';
-  args: [
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface Fin5 extends FunctionCall {
-  type: 'booleanfunction';
-  name: 'in5';
-  args: [
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface Fin6 extends FunctionCall {
-  type: 'booleanfunction';
-  name: 'in6';
-  args: [
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface Fin7 extends FunctionCall {
-  type: 'booleanfunction';
-  name: 'in7';
-  args: [
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface Fin8 extends FunctionCall {
-  type: 'booleanfunction';
-  name: 'in8';
-  args: [
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface Fin9 extends FunctionCall {
-  type: 'booleanfunction';
-  name: 'in9';
-  args: [
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface FinArray extends FunctionCall {
-  type: 'booleanfunction';
-  name: 'inArray';
-  args: [
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface Fint2bbool extends FunctionCall {
-  type: 'booleanfunction';
-  name: 'int2bbool';
-  args: [
-    Expression<number>
-  ];
-};
-
-export interface Fint2ddouble extends FunctionCall {
-  type: 'numberfunction';
-  name: 'int2ddouble';
-  args: [
-    Expression<number>
-  ];
-};
-
-export interface Fintersection extends FunctionCall {
-  type: 'stringfunction';
-  name: 'intersection';
-  args: [
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface Fintersects extends FunctionCall {
-  type: 'booleanfunction';
-  name: 'intersects';
-  args: [
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface Fintersects3D extends FunctionCall {
-  type: 'numberfunction';
-  name: 'intersects3D';
-  args: [
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface FisCached extends FunctionCall {
-  type: 'booleanfunction';
-  name: 'isCached';
-  args: [
-    Expression<string>
-  ];
-};
-
-export interface FisCoverage extends FunctionCall {
-  type: 'booleanfunction';
-  name: 'isCoverage';
-};
-
-export interface FisInstanceOf extends FunctionCall {
-  type: 'booleanfunction';
-  name: 'isInstanceOf';
-  args: [
-    Expression<string>
-  ];
-};
-
-export interface FisLike extends FunctionCall {
-  type: 'booleanfunction';
-  name: 'isLike';
-  args: [
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface FisNull extends FunctionCall {
-  type: 'booleanfunction';
-  name: 'isNull';
-  args: [
-    Expression<string>
-  ];
-};
-
-export interface FisWithinDistance extends FunctionCall {
-  type: 'booleanfunction';
-  name: 'isWithinDistance';
-  args: [
-    Expression<string>,
-    Expression<string>,
-    Expression<number>
-  ];
-};
-
-export interface FisWithinDistance3D extends FunctionCall {
-  type: 'numberfunction';
-  name: 'isWithinDistance3D';
-  args: [
-    Expression<string>,
-    Expression<string>,
-    Expression<number>
-  ];
-};
-
-export interface FjsonPointer extends FunctionCall {
-  type: 'stringfunction';
-  name: 'jsonPointer';
-  args: [
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface Flapply extends FunctionCall {
-  type: 'stringfunction';
-  name: 'lapply';
-  args: [
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface Flength extends FunctionCall {
-  type: 'numberfunction';
-  name: 'length';
-  args: [
-    Expression<string>
-  ];
-};
-
-export interface FlessEqualThan extends FunctionCall {
-  type: 'booleanfunction';
-  name: 'lessEqualThan';
-  args: [
-    Expression<number>,
-    Expression<number>
-  ];
-};
-
-export interface FlessThan extends FunctionCall {
-  type: 'booleanfunction';
-  name: 'lessThan';
-  args: [
-    Expression<number>,
-    Expression<number>
-  ];
-};
-
-export interface Flighten extends FunctionCall {
-  type: 'stringfunction';
-  name: 'lighten';
-  args: [
-    Expression<string>,
-    Expression<number>,
-    Expression<string>
-  ];
-};
-
-export interface Flist extends FunctionCall {
-  type: 'stringfunction';
-  name: 'list';
-  args: [
-    Expression<string>
-  ];
-};
-
-export interface FlistMultiply extends FunctionCall {
-  type: 'stringfunction';
-  name: 'listMultiply';
-  args: [
-    Expression<number>,
-    Expression<string>
-  ];
-};
-
-export interface Flitem extends FunctionCall {
-  type: 'stringfunction';
-  name: 'litem';
-  args: [
-    Expression<string>,
-    Expression<number>
-  ];
-};
-
-export interface Fliterate extends FunctionCall {
-  type: 'stringfunction';
-  name: 'literate';
-  args: [
-    Expression<string>,
-    Expression<number>,
-    Expression<string>
-  ];
-};
-
-export interface Flog extends FunctionCall {
+/**
+ * Returns the natural logarithm (base e) of x
+ */
+export interface Flog extends FunctionCall<number> {
   type: 'numberfunction';
   name: 'log';
   args: [
@@ -839,98 +203,25 @@ export interface Flog extends FunctionCall {
   ];
 };
 
-export interface FmapGet extends FunctionCall {
-  type: 'stringfunction';
-  name: 'mapGet';
-  args: [
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface Fmax extends FunctionCall {
+/**
+ * Returns the maximum between argument[0], …, argument[n]
+ */
+export interface Fmax extends FunctionCall<number> {
   type: 'numberfunction';
   name: 'max';
-  args: [
-    Expression<number>,
-    Expression<number>
-  ];
+  args: Expression<number>[];
 };
 
-export interface Fmax_2 extends FunctionCall {
-  type: 'numberfunction';
-  name: 'max_2';
-  args: [
-    Expression<number>,
-    Expression<number>
-  ];
-};
-
-export interface Fmax_3 extends FunctionCall {
-  type: 'numberfunction';
-  name: 'max_3';
-  args: [
-    Expression<number>,
-    Expression<number>
-  ];
-};
-
-export interface Fmax_4 extends FunctionCall {
-  type: 'numberfunction';
-  name: 'max_4';
-  args: [
-    Expression<number>,
-    Expression<number>
-  ];
-};
-
-export interface Fmin extends FunctionCall {
+/**
+ * Returns the minimum between argument[0], …, argument[n]
+ */
+export interface Fmin extends FunctionCall<number> {
   type: 'numberfunction';
   name: 'min';
-  args: [
-    Expression<number>,
-    Expression<number>
-  ];
+  args: Expression<number>[];
 };
 
-export interface Fmin_2 extends FunctionCall {
-  type: 'numberfunction';
-  name: 'min_2';
-  args: [
-    Expression<number>,
-    Expression<number>
-  ];
-};
-
-export interface Fmin_3 extends FunctionCall {
-  type: 'numberfunction';
-  name: 'min_3';
-  args: [
-    Expression<number>,
-    Expression<number>
-  ];
-};
-
-export interface Fmin_4 extends FunctionCall {
-  type: 'numberfunction';
-  name: 'min_4';
-  args: [
-    Expression<number>,
-    Expression<number>
-  ];
-};
-
-export interface Fmix extends FunctionCall {
-  type: 'stringfunction';
-  name: 'mix';
-  args: [
-    Expression<string>,
-    Expression<string>,
-    Expression<number>
-  ];
-};
-
-export interface Fmodulo extends FunctionCall {
+export interface Fmodulo extends FunctionCall<number> {
   type: 'numberfunction';
   name: 'modulo';
   args: [
@@ -939,24 +230,12 @@ export interface Fmodulo extends FunctionCall {
   ];
 };
 
-export interface Fnot extends FunctionCall {
-  type: 'booleanfunction';
-  name: 'not';
-  args: [
-    Expression<boolean>
-  ];
-};
-
-export interface FnotEqualTo extends FunctionCall {
-  type: 'booleanfunction';
-  name: 'notEqualTo';
-  args: [
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface FnumberFormat extends FunctionCall {
+/**
+ * Formats the number (argument[1]) according to the specified format (arguments[0]) using the default locale
+ * or the one provided (argument[2]) as an optional argument. The format syntax can be found
+ * in the Java DecimalFormat javadocs
+ */
+export interface FnumberFormat extends FunctionCall<string> {
   type: 'stringfunction';
   name: 'numberFormat';
   args: [
@@ -966,37 +245,11 @@ export interface FnumberFormat extends FunctionCall {
   ];
 };
 
-export interface FnumberFormat2 extends FunctionCall {
-  type: 'stringfunction';
-  name: 'numberFormat2';
-  args: [
-    Expression<string>,
-    Expression<number>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface Foverlaps extends FunctionCall {
-  type: 'stringfunction';
-  name: 'overlaps';
-  args: [
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface Fparameter extends FunctionCall {
-  type: 'stringfunction';
-  name: 'parameter';
-  args: [
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface FparseBoolean extends FunctionCall {
+/**
+ * Parses a string into a boolean. The empty string, f, 0.0 and 0 are considered false, everything
+ * else is considered true.
+ */
+export interface FparseBoolean extends FunctionCall<boolean> {
   type: 'booleanfunction';
   name: 'parseBoolean';
   args: [
@@ -1004,36 +257,18 @@ export interface FparseBoolean extends FunctionCall {
   ];
 };
 
-export interface FparseDouble extends FunctionCall {
-  type: 'numberfunction';
-  name: 'parseDouble';
-  args: [
-    Expression<string>
-  ];
-};
-
-export interface FparseInt extends FunctionCall {
-  type: 'numberfunction';
-  name: 'parseInt';
-  args: [
-    Expression<string>
-  ];
-};
-
-export interface FparseLong extends FunctionCall {
-  type: 'numberfunction';
-  name: 'parseLong';
-  args: [
-    Expression<string>
-  ];
-};
-
-export interface Fpi extends FunctionCall {
+/**
+ * Returns an approximation of pi, the ratio of the circumference of a circle to its diameter
+ */
+export interface Fpi extends FunctionCall<number> {
   type: 'numberfunction';
   name: 'pi';
 };
 
-export interface Fpow extends FunctionCall {
+/**
+ * Returns the value of base (argument[0]) raised to the power of exponent (arguments[1])
+ */
+export interface Fpow extends FunctionCall<number> {
   type: 'numberfunction';
   name: 'pow';
   args: [
@@ -1042,7 +277,11 @@ export interface Fpow extends FunctionCall {
   ];
 };
 
-export interface Fproperty extends FunctionCall {
+/**
+ * Returns the value of the property propertyName. Allows property names to be compute
+ *  or specified by Variable substitution in SLD.
+ */
+export interface Fproperty extends FunctionCall<string> {
   type: 'stringfunction';
   name: 'property';
   args: [
@@ -1050,32 +289,20 @@ export interface Fproperty extends FunctionCall {
   ];
 };
 
-export interface Frandom extends FunctionCall {
+/**
+ * Returns a Double value with a positive sign, greater than or equal to 0.0 and less than 1.0.
+ */
+export interface Frandom extends FunctionCall<number> {
   type: 'numberfunction';
   name: 'random';
 };
 
-export interface Frelate extends FunctionCall {
-  type: 'stringfunction';
-  name: 'relate';
-  args: [
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface FrescaleToPixels extends FunctionCall {
-  type: 'stringfunction';
-  name: 'rescaleToPixels';
-  args: [
-    Expression<string>,
-    Expression<string>,
-    Expression<number>,
-    Expression<string>
-  ];
-};
-
-export interface Frint extends FunctionCall {
+/**
+ * Returns the Double value that is closest in value to the argument and is equal to a mathematical
+ * integer. If two double values that are mathematical integers are equally close, the result is the
+ * integer value that is even.
+ */
+export interface Frint extends FunctionCall<number> {
   type: 'numberfunction';
   name: 'rint';
   args: [
@@ -1083,7 +310,10 @@ export interface Frint extends FunctionCall {
   ];
 };
 
-export interface Fround extends FunctionCall {
+/**
+ * Returns the closest number to argument[0].
+ */
+export interface Fround extends FunctionCall<number> {
   type: 'numberfunction';
   name: 'round';
   args: [
@@ -1091,42 +321,10 @@ export interface Fround extends FunctionCall {
   ];
 };
 
-export interface Fround_2 extends FunctionCall {
-  type: 'numberfunction';
-  name: 'round_2';
-  args: [
-    Expression<number>
-  ];
-};
-
-export interface FroundDouble extends FunctionCall {
-  type: 'numberfunction';
-  name: 'roundDouble';
-  args: [
-    Expression<number>
-  ];
-};
-
-export interface Fsaturate extends FunctionCall {
-  type: 'stringfunction';
-  name: 'saturate';
-  args: [
-    Expression<string>,
-    Expression<number>,
-    Expression<string>
-  ];
-};
-
-export interface Fshade extends FunctionCall {
-  type: 'stringfunction';
-  name: 'shade';
-  args: [
-    Expression<string>,
-    Expression<number>
-  ];
-};
-
-export interface Fsin extends FunctionCall {
+/**
+ * Returns the sine of an angle expressed in radians
+ */
+export interface Fsin extends FunctionCall<number> {
   type: 'numberfunction';
   name: 'sin';
   args: [
@@ -1134,24 +332,10 @@ export interface Fsin extends FunctionCall {
   ];
 };
 
-export interface Fsize extends FunctionCall {
-  type: 'numberfunction';
-  name: 'size';
-  args: [
-    Expression<string>
-  ];
-};
-
-export interface Fspin extends FunctionCall {
-  type: 'stringfunction';
-  name: 'spin';
-  args: [
-    Expression<string>,
-    Expression<number>
-  ];
-};
-
-export interface Fsqrt extends FunctionCall {
+/**
+ * Returns the square root of argument[0]
+ */
+export interface Fsqrt extends FunctionCall<number> {
   type: 'numberfunction';
   name: 'sqrt';
   args: [
@@ -1159,23 +343,11 @@ export interface Fsqrt extends FunctionCall {
   ];
 };
 
-export interface FstartAngle extends FunctionCall {
-  type: 'numberfunction';
-  name: 'startAngle';
-  args: [
-    Expression<string>
-  ];
-};
-
-export interface FstartPoint extends FunctionCall {
-  type: 'stringfunction';
-  name: 'startPoint';
-  args: [
-    Expression<string>
-  ];
-};
-
-export interface FstrAbbreviate extends FunctionCall {
+/**
+ * Abbreviates the sentence (argument[0]) at first space beyond lower (argument[1])
+ * or at upper (argument[2]) if no space.Appends append (argument[3]) if string is abbreviated.
+ */
+export interface FstrAbbreviate extends FunctionCall<string> {
   type: 'stringfunction';
   name: 'strAbbreviate';
   args: [
@@ -1186,7 +358,10 @@ export interface FstrAbbreviate extends FunctionCall {
   ];
 };
 
-export interface FstrCapitalize extends FunctionCall {
+/**
+ * Fully capitalizes the sentence. For example, “HoW aRe YOU?” will be turned into “How Are You?”
+ */
+export interface FstrCapitalize extends FunctionCall<string> {
   type: 'stringfunction';
   name: 'strCapitalize';
   args: [
@@ -1194,7 +369,10 @@ export interface FstrCapitalize extends FunctionCall {
   ];
 };
 
-export interface FstrConcat extends FunctionCall {
+/**
+ * Concatenates the two strings into one
+ */
+export interface FstrConcat extends FunctionCall<string> {
   type: 'stringfunction';
   name: 'strConcat';
   args: [
@@ -1203,7 +381,10 @@ export interface FstrConcat extends FunctionCall {
   ];
 };
 
-export interface FstrDefaultIfBlank extends FunctionCall {
+/**
+ * Returns default (argument[1]) if str (argument[0]) is empty, blank or null
+ */
+export interface FstrDefaultIfBlank extends FunctionCall<string> {
   type: 'stringfunction';
   name: 'strDefaultIfBlank';
   args: [
@@ -1212,7 +393,10 @@ export interface FstrDefaultIfBlank extends FunctionCall {
   ];
 };
 
-export interface FstrEndsWith extends FunctionCall {
+/**
+ * Returns true if string (argument[0]) ends with suffix (argument[1])
+  */
+export interface FstrEndsWith extends FunctionCall<boolean> {
   type: 'booleanfunction';
   name: 'strEndsWith';
   args: [
@@ -1221,7 +405,10 @@ export interface FstrEndsWith extends FunctionCall {
   ];
 };
 
-export interface FstrEqualsIgnoreCase extends FunctionCall {
+/**
+ * Returns true if the two strings are equal ignoring case considerations
+ */
+export interface FstrEqualsIgnoreCase extends FunctionCall<boolean> {
   type: 'booleanfunction';
   name: 'strEqualsIgnoreCase';
   args: [
@@ -1230,7 +417,11 @@ export interface FstrEqualsIgnoreCase extends FunctionCall {
   ];
 };
 
-export interface FstrIndexOf extends FunctionCall {
+/**
+ * Returns the index within this string (argument[0]) of the first occurrence of the specified
+ * substring (argument[1]), or -1 if not found
+ */
+export interface FstrIndexOf extends FunctionCall<number> {
   type: 'numberfunction';
   name: 'strIndexOf';
   args: [
@@ -1239,18 +430,11 @@ export interface FstrIndexOf extends FunctionCall {
   ];
 };
 
-export interface FstringTemplate extends FunctionCall {
-  type: 'stringfunction';
-  name: 'stringTemplate';
-  args: [
-    Expression<string>,
-    Expression<string>,
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface FstrLastIndexOf extends FunctionCall {
+/**
+ * Returns the index within this string (arguments[0]) of the last occurrence of the specified
+ * substring (arguments[1]), or -1 if not found
+ */
+export interface FstrLastIndexOf extends FunctionCall<number> {
   type: 'numberfunction';
   name: 'strLastIndexOf';
   args: [
@@ -1259,7 +443,10 @@ export interface FstrLastIndexOf extends FunctionCall {
   ];
 };
 
-export interface FstrLength extends FunctionCall{
+/**
+ * Returns the string length
+ */
+export interface FstrLength extends FunctionCall<number>{
   type: 'numberfunction';
   name: 'strLength';
   args: [
@@ -1267,7 +454,11 @@ export interface FstrLength extends FunctionCall{
   ];
 };
 
-export interface FstrMatches extends FunctionCall {
+/**
+ * Returns true if the string (arguments[0]) matches the specified regular expression (arguments[1]).
+ * For the full syntax of the pattern specification see the Java Pattern class javadocs
+ */
+export interface FstrMatches extends FunctionCall<boolean> {
   type: 'booleanfunction';
   name: 'strMatches';
   args: [
@@ -1276,17 +467,13 @@ export interface FstrMatches extends FunctionCall {
   ];
 };
 
-export interface FstrPosition extends FunctionCall {
-  type: 'stringfunction';
-  name: 'strPosition';
-  args: [
-    Expression<string>,
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface FstrReplace extends FunctionCall {
+/**
+ * Returns the string (argument[0]) with the pattern (argument[1]) replaced with the given
+ * replacement (argument[2]) text. If the global argument (argument[3]) is true then all occurrences of the pattern
+ * will be replaced, otherwise only the first. For the full syntax of the pattern specification see
+ * the Java Pattern class javadocs
+ */
+export interface FstrReplace extends FunctionCall<string> {
   type: 'stringfunction';
   name: 'strReplace';
   args: [
@@ -1297,7 +484,10 @@ export interface FstrReplace extends FunctionCall {
   ];
 };
 
-export interface FstrStartsWith extends FunctionCall {
+/**
+ * Returns true if string (argument[0]) starts with prefix (argument[1]).
+ */
+export interface FstrStartsWith extends FunctionCall<boolean> {
   type: 'booleanfunction';
   name: 'strStartsWith';
   args: [
@@ -1306,7 +496,10 @@ export interface FstrStartsWith extends FunctionCall {
   ];
 };
 
-export interface FstrStripAccents extends FunctionCall {
+/**
+ * Removes diacritics (~= accents) from a string. The case will not be altered.
+ */
+export interface FstrStripAccents extends FunctionCall<string> {
   type: 'stringfunction';
   name: 'strStripAccents';
   args: [
@@ -1314,7 +507,12 @@ export interface FstrStripAccents extends FunctionCall {
   ];
 };
 
-export interface FstrSubstring extends FunctionCall {
+/**
+ * Returns a new string that is a substring of this string (argument[0]). The substring begins
+ * at the specified begin (argument[1]) and extends to the character at index endIndex (argument[2]) - 1
+ * (indexes are zero-based).
+ */
+export interface FstrSubstring extends FunctionCall<string> {
   type: 'stringfunction';
   name: 'strSubstring';
   args: [
@@ -1324,7 +522,11 @@ export interface FstrSubstring extends FunctionCall {
   ];
 };
 
-export interface FstrSubstringStart extends FunctionCall {
+/**
+ * Returns a new string that is a substring of this string (argument[0]). The substring begins
+ * at the specified begin (arguments[1]) and extends to the last character of the string
+ */
+export interface FstrSubstringStart extends FunctionCall<string> {
   type: 'stringfunction';
   name: 'strSubstringStart';
   args: [
@@ -1333,7 +535,10 @@ export interface FstrSubstringStart extends FunctionCall {
   ];
 };
 
-export interface FstrToLowerCase extends FunctionCall {
+/**
+ * Returns the lower case version of the string
+ */
+export interface FstrToLowerCase extends FunctionCall<string> {
   type: 'stringfunction';
   name: 'strToLowerCase';
   args: [
@@ -1341,7 +546,10 @@ export interface FstrToLowerCase extends FunctionCall {
   ];
 };
 
-export interface FstrToUpperCase extends FunctionCall {
+/**
+ * Returns the upper case version of the string
+ */
+export interface FstrToUpperCase extends FunctionCall<string> {
   type: 'stringfunction';
   name: 'strToUpperCase';
   args: [
@@ -1349,7 +557,10 @@ export interface FstrToUpperCase extends FunctionCall {
   ];
 };
 
-export interface FstrTrim extends FunctionCall {
+/**
+ * Returns a copy of the string, with leading and trailing blank-space omitted
+ */
+export interface FstrTrim extends FunctionCall<string> {
   type: 'stringfunction';
   name: 'strTrim';
   args: [
@@ -1357,26 +568,10 @@ export interface FstrTrim extends FunctionCall {
   ];
 };
 
-export interface FstrTrim2 extends FunctionCall {
-  type: 'stringfunction';
-  name: 'strTrim2';
-  args: [
-    Expression<string>,
-    Expression<string>,
-    Expression<string>
-  ];
-};
-
-export interface FstrURLEncode extends FunctionCall {
-  type: 'stringfunction';
-  name: 'strURLEncode';
-  args: [
-    Expression<string>,
-    Expression<boolean>
-  ];
-};
-
-export interface Ftan extends FunctionCall {
+/**
+ * Returns the trigonometric tangent of angle expressed in radians
+ */
+export interface Ftan extends FunctionCall<number> {
   type: 'numberfunction';
   name: 'tan';
   args: [
@@ -1384,16 +579,10 @@ export interface Ftan extends FunctionCall {
   ];
 };
 
-export interface Ftint extends FunctionCall {
-  type: 'stringfunction';
-  name: 'tint';
-  args: [
-    Expression<string>,
-    Expression<number>
-  ];
-};
-
-export interface FtoDegrees extends FunctionCall {
+/**
+ * Converts an angle expressed in radians into degrees
+ */
+export interface FtoDegrees extends FunctionCall<number> {
   type: 'numberfunction';
   name: 'toDegrees';
   args: [
@@ -1401,7 +590,10 @@ export interface FtoDegrees extends FunctionCall {
   ];
 };
 
-export interface FtoRadians extends FunctionCall {
+/**
+ * Converts an angle expressed in radians into degrees
+ */
+export interface FtoRadians extends FunctionCall<number> {
   type: 'numberfunction';
   name: 'toRadians';
   args: [

--- a/functions.ts
+++ b/functions.ts
@@ -1,1172 +1,122 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import {
   FunctionCall,
-  LiteralValue
+  Expression
 } from './style';
-
-export interface Fabs extends FunctionCall<number> {
-  name: 'abs';
-  args: [
-    LiteralValue<number>
-  ];
-};
-
-export interface Fabs_2 extends FunctionCall<number> {
-  name: 'abs_2';
-  args: [
-    LiteralValue<number>
-  ];
-};
-
-export interface Fabs_3 extends FunctionCall<number> {
-  name: 'abs_3';
-  args: [
-    LiteralValue<number>
-  ];
-};
-
-export interface Fabs_4 extends FunctionCall<number> {
-  name: 'abs_4';
-  args: [
-    LiteralValue<number>
-  ];
-};
-
-export interface Facos extends FunctionCall<number> {
-  name: 'acos';
-  args: [
-    LiteralValue<number>
-  ];
-};
-
-export interface Farray extends FunctionCall<string> {
-  name: 'array';
-};
-
-export interface Fasin extends FunctionCall<number> {
-  name: 'asin';
-  args: [
-    LiteralValue<number>
-  ];
-};
-
-export interface Fatan extends FunctionCall<number> {
-  name: 'atan';
-  args: [
-    LiteralValue<number>
-  ];
-};
-
-export interface Fatan2 extends FunctionCall<number> {
-  name: 'atan2';
-  args: [
-    LiteralValue<number>,
-    LiteralValue<number>
-  ];
-};
-
-export interface FattributeCount extends FunctionCall<string> {
-  name: 'attributeCount';
-  args: [
-    LiteralValue<string>
-  ];
-};
-
-export interface Fbetween extends FunctionCall<boolean> {
-  name: 'between';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface FboundedBy extends FunctionCall<string> {
-  name: 'boundedBy';
-};
-
-export interface Fceil extends FunctionCall<number> {
-  name: 'ceil';
-  args: [
-    LiteralValue<number>
-  ];
-};
-
-export interface Fclassify extends FunctionCall<string> {
-  name: 'classify';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Fcontains extends FunctionCall<boolean> {
-  name: 'contains';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Fcontrast extends FunctionCall<string> {
-  name: 'contrast';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<number>
-  ];
-};
-
-export interface Fconvert extends FunctionCall<string> {
-  name: 'convert';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Fcos extends FunctionCall<number> {
-  name: 'cos';
-  args: [
-    LiteralValue<number>
-  ];
-};
-
-export interface Fcrosses extends FunctionCall<boolean> {
-  name: 'crosses';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Fdarken extends FunctionCall<string> {
-  name: 'darken';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<number>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Fdesaturate extends FunctionCall<string> {
-  name: 'desaturate';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<number>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Fdifference extends FunctionCall<string> {
-  name: 'difference';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Fdisjoint extends FunctionCall<boolean> {
-  name: 'disjoint';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Fdisjoint3D extends FunctionCall<number> {
-  name: 'disjoint3D';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Fdistance extends FunctionCall<number> {
-  name: 'distance';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Fdistance3D extends FunctionCall<number> {
-  name: 'distance3D';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Fdouble2bool extends FunctionCall<boolean> {
-  name: 'double2bool';
-  args: [
-    LiteralValue<number>
-  ];
-};
-
-export interface FendAngle extends FunctionCall<number> {
-  name: 'endAngle';
-  args: [
-    LiteralValue<string>
-  ];
-};
-
-export interface FendPoint extends FunctionCall<string> {
-  name: 'endPoint';
-  args: [
-    LiteralValue<string>
-  ];
-};
-
-export interface Fenv extends FunctionCall<string> {
-  name: 'env';
-  args: [
-    LiteralValue<string>
-  ];
-};
-
-export interface FequalsExact extends FunctionCall<boolean> {
-  name: 'equalsExact';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface FequalsExactTolerance extends FunctionCall<boolean> {
-  name: 'equalsExactTolerance';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<number>
-  ];
-};
-
-export interface FequalTo extends FunctionCall<boolean> {
-  name: 'equalTo';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Fexp extends FunctionCall<number> {
-  name: 'exp';
-  args: [
-    LiteralValue<number>
-  ];
-};
-
-export interface Ffloor extends FunctionCall<number> {
-  name: 'floor';
-  args: [
-    LiteralValue<number>
-  ];
-};
-
-export interface Fgrayscale extends FunctionCall<string> {
-  name: 'grayscale';
-  args: [
-    LiteralValue<string>
-  ];
-};
-
-export interface FgreaterEqualThan extends FunctionCall<boolean> {
-  name: 'greaterEqualThan';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface FgreaterThan extends FunctionCall<boolean> {
-  name: 'greaterThan';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Fhsl extends FunctionCall<string> {
-  name: 'hsl';
-  args: [
-    LiteralValue<number>,
-    LiteralValue<number>,
-    LiteralValue<number>
-  ];
-};
-
-export interface Fid extends FunctionCall<string> {
-  name: 'id';
-};
-
-export interface Fif_then_else extends FunctionCall<string> {
-  name: 'if_then_else';
-  args: [
-    LiteralValue<boolean>,
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Fin extends FunctionCall<boolean> {
-  name: 'in';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Fin10 extends FunctionCall<boolean> {
-  name: 'in10';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Fin2 extends FunctionCall<boolean> {
-  name: 'in2';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Fin3 extends FunctionCall<boolean> {
-  name: 'in3';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Fin4 extends FunctionCall<boolean> {
-  name: 'in4';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Fin5 extends FunctionCall<boolean> {
-  name: 'in5';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Fin6 extends FunctionCall<boolean> {
-  name: 'in6';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Fin7 extends FunctionCall<boolean> {
-  name: 'in7';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Fin8 extends FunctionCall<boolean> {
-  name: 'in8';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Fin9 extends FunctionCall<boolean> {
-  name: 'in9';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface FinArray extends FunctionCall<boolean> {
-  name: 'inArray';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Fint2bbool extends FunctionCall<boolean> {
-  name: 'int2bbool';
-  args: [
-    LiteralValue<number>
-  ];
-};
-
-export interface Fint2ddouble extends FunctionCall<number> {
-  name: 'int2ddouble';
-  args: [
-    LiteralValue<number>
-  ];
-};
-
-export interface Fintersection extends FunctionCall<string> {
-  name: 'intersection';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Fintersects extends FunctionCall<boolean> {
-  name: 'intersects';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Fintersects3D extends FunctionCall<number> {
-  name: 'intersects3D';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface FisCached extends FunctionCall<boolean> {
-  name: 'isCached';
-  args: [
-    LiteralValue<string>
-  ];
-};
-
-export interface FisCoverage extends FunctionCall<boolean> {
-  name: 'isCoverage';
-};
-
-export interface FisInstanceOf extends FunctionCall<boolean> {
-  name: 'isInstanceOf';
-  args: [
-    LiteralValue<string>
-  ];
-};
-
-export interface FisLike extends FunctionCall<boolean> {
-  name: 'isLike';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface FisNull extends FunctionCall<boolean> {
-  name: 'isNull';
-  args: [
-    LiteralValue<string>
-  ];
-};
-
-export interface FisWithinDistance extends FunctionCall<boolean> {
-  name: 'isWithinDistance';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<number>
-  ];
-};
-
-export interface FisWithinDistance3D extends FunctionCall<number> {
-  name: 'isWithinDistance3D';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<number>
-  ];
-};
-
-export interface FjsonPointer extends FunctionCall<string> {
-  name: 'jsonPointer';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Flapply extends FunctionCall<string> {
-  name: 'lapply';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Flength extends FunctionCall<number> {
-  name: 'length';
-  args: [
-    LiteralValue<string>
-  ];
-};
-
-export interface FlessEqualThan extends FunctionCall<boolean> {
-  name: 'lessEqualThan';
-  args: [
-    LiteralValue<number>,
-    LiteralValue<number>
-  ];
-};
-
-export interface FlessThan extends FunctionCall<boolean> {
-  name: 'lessThan';
-  args: [
-    LiteralValue<number>,
-    LiteralValue<number>
-  ];
-};
-
-export interface Flighten extends FunctionCall<string> {
-  name: 'lighten';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<number>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Flist extends FunctionCall<string> {
-  name: 'list';
-  args: [
-    LiteralValue<string>
-  ];
-};
-
-export interface FlistMultiply extends FunctionCall<string> {
-  name: 'listMultiply';
-  args: [
-    LiteralValue<number>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Flitem extends FunctionCall<string> {
-  name: 'litem';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<number>
-  ];
-};
-
-export interface Fliterate extends FunctionCall<string> {
-  name: 'literate';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<number>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Flog extends FunctionCall<number> {
-  name: 'log';
-  args: [
-    LiteralValue<number>
-  ];
-};
-
-export interface FmapGet extends FunctionCall<string> {
-  name: 'mapGet';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Fmax extends FunctionCall<number> {
-  name: 'max';
-  args: [
-    LiteralValue<number>,
-    LiteralValue<number>
-  ];
-};
-
-export interface Fmax_2 extends FunctionCall<number> {
-  name: 'max_2';
-  args: [
-    LiteralValue<number>,
-    LiteralValue<number>
-  ];
-};
-
-export interface Fmax_3 extends FunctionCall<number> {
-  name: 'max_3';
-  args: [
-    LiteralValue<number>,
-    LiteralValue<number>
-  ];
-};
-
-export interface Fmax_4 extends FunctionCall<number> {
-  name: 'max_4';
-  args: [
-    LiteralValue<number>,
-    LiteralValue<number>
-  ];
-};
-
-export interface Fmin extends FunctionCall<number> {
-  name: 'min';
-  args: [
-    LiteralValue<number>,
-    LiteralValue<number>
-  ];
-};
-
-export interface Fmin_2 extends FunctionCall<number> {
-  name: 'min_2';
-  args: [
-    LiteralValue<number>,
-    LiteralValue<number>
-  ];
-};
-
-export interface Fmin_3 extends FunctionCall<number> {
-  name: 'min_3';
-  args: [
-    LiteralValue<number>,
-    LiteralValue<number>
-  ];
-};
-
-export interface Fmin_4 extends FunctionCall<number> {
-  name: 'min_4';
-  args: [
-    LiteralValue<number>,
-    LiteralValue<number>
-  ];
-};
-
-export interface Fmix extends FunctionCall<string> {
-  name: 'mix';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<number>
-  ];
-};
-
-export interface Fmodulo extends FunctionCall<number> {
-  name: 'modulo';
-  args: [
-    LiteralValue<number>,
-    LiteralValue<number>
-  ];
-};
-
-export interface Fnot extends FunctionCall<boolean> {
-  name: 'not';
-  args: [
-    LiteralValue<boolean>
-  ];
-};
-
-export interface FnotEqualTo extends FunctionCall<boolean> {
-  name: 'notEqualTo';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface FnumberFormat extends FunctionCall<string> {
-  name: 'numberFormat';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<number>,
-    LiteralValue<string>
-  ];
-};
-
-export interface FnumberFormat2 extends FunctionCall<string> {
-  name: 'numberFormat2';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<number>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Foverlaps extends FunctionCall<string> {
-  name: 'overlaps';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Fparameter extends FunctionCall<string> {
-  name: 'parameter';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface FparseBoolean extends FunctionCall<boolean> {
-  name: 'parseBoolean';
-  args: [
-    LiteralValue<string>
-  ];
-};
-
-export interface FparseDouble extends FunctionCall<number> {
-  name: 'parseDouble';
-  args: [
-    LiteralValue<string>
-  ];
-};
-
-export interface FparseInt extends FunctionCall<number> {
-  name: 'parseInt';
-  args: [
-    LiteralValue<string>
-  ];
-};
-
-export interface FparseLong extends FunctionCall<number> {
-  name: 'parseLong';
-  args: [
-    LiteralValue<string>
-  ];
-};
-
-export interface Fpi extends FunctionCall<number> {
-  name: 'pi';
-};
-
-export interface Fpow extends FunctionCall<number> {
-  name: 'pow';
-  args: [
-    LiteralValue<number>,
-    LiteralValue<number>
-  ];
-};
-
-export interface Fproperty extends FunctionCall<string> {
-  name: 'property';
-  args: [
-    LiteralValue<string>
-  ];
-};
-
-export interface Frandom extends FunctionCall<number> {
-  name: 'random';
-};
-
-export interface Frelate extends FunctionCall<string> {
-  name: 'relate';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface FrescaleToPixels extends FunctionCall<string> {
-  name: 'rescaleToPixels';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<number>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Frint extends FunctionCall<number> {
-  name: 'rint';
-  args: [
-    LiteralValue<number>
-  ];
-};
-
-export interface Fround extends FunctionCall<number> {
-  name: 'round';
-  args: [
-    LiteralValue<number>
-  ];
-};
-
-export interface Fround_2 extends FunctionCall<number> {
-  name: 'round_2';
-  args: [
-    LiteralValue<number>
-  ];
-};
-
-export interface FroundDouble extends FunctionCall<number> {
-  name: 'roundDouble';
-  args: [
-    LiteralValue<number>
-  ];
-};
-
-export interface Fsaturate extends FunctionCall<string> {
-  name: 'saturate';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<number>,
-    LiteralValue<string>
-  ];
-};
-
-export interface Fshade extends FunctionCall<string> {
-  name: 'shade';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<number>
-  ];
-};
-
-export interface Fsin extends FunctionCall<number> {
-  name: 'sin';
-  args: [
-    LiteralValue<number>
-  ];
-};
-
-export interface Fsize extends FunctionCall<number> {
-  name: 'size';
-  args: [
-    LiteralValue<string>
-  ];
-};
-
-export interface Fspin extends FunctionCall<string> {
-  name: 'spin';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<number>
-  ];
-};
-
-export interface Fsqrt extends FunctionCall<number> {
-  name: 'sqrt';
-  args: [
-    LiteralValue<number>
-  ];
-};
-
-export interface FstartAngle extends FunctionCall<number> {
-  name: 'startAngle';
-  args: [
-    LiteralValue<string>
-  ];
-};
-
-export interface FstartPoint extends FunctionCall<string> {
-  name: 'startPoint';
-  args: [
-    LiteralValue<string>
-  ];
-};
-
-export interface FstrAbbreviate extends FunctionCall<string> {
-  name: 'strAbbreviate';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<number>,
-    LiteralValue<number>,
-    LiteralValue<string>
-  ];
-};
-
-export interface FstrCapitalize extends FunctionCall<string> {
-  name: 'strCapitalize';
-  args: [
-    LiteralValue<string>
-  ];
-};
-
-export interface FstrConcat extends FunctionCall<string> {
-  name: 'strConcat';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface FstrDefaultIfBlank extends FunctionCall<string> {
-  name: 'strDefaultIfBlank';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface FstrEndsWith extends FunctionCall<boolean> {
-  name: 'strEndsWith';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface FstrEqualsIgnoreCase extends FunctionCall<boolean> {
-  name: 'strEqualsIgnoreCase';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface FstrIndexOf extends FunctionCall<number> {
-  name: 'strIndexOf';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface FstringTemplate extends FunctionCall<string> {
-  name: 'stringTemplate';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface FstrLastIndexOf extends FunctionCall<number> {
-  name: 'strLastIndexOf';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface FstrLength extends FunctionCall<number> {
-  name: 'strLength';
-  args: [
-    LiteralValue<string>
-  ];
-};
-
-export interface FstrMatches extends FunctionCall<boolean> {
-  name: 'strMatches';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface FstrPosition extends FunctionCall<string> {
-  name: 'strPosition';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface FstrReplace extends FunctionCall<string> {
-  name: 'strReplace';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<boolean>
-  ];
-};
-
-export interface FstrStartsWith extends FunctionCall<boolean> {
-  name: 'strStartsWith';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface FstrStripAccents extends FunctionCall<string> {
-  name: 'strStripAccents';
-  args: [
-    LiteralValue<string>
-  ];
-};
-
-export interface FstrSubstring extends FunctionCall<string> {
-  name: 'strSubstring';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<number>,
-    LiteralValue<number>
-  ];
-};
-
-export interface FstrSubstringStart extends FunctionCall<string> {
-  name: 'strSubstringStart';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<number>
-  ];
-};
-
-export interface FstrToLowerCase extends FunctionCall<string> {
-  name: 'strToLowerCase';
-  args: [
-    LiteralValue<string>
-  ];
-};
-
-export interface FstrToUpperCase extends FunctionCall<string> {
-  name: 'strToUpperCase';
-  args: [
-    LiteralValue<string>
-  ];
-};
-
-export interface FstrTrim extends FunctionCall<string> {
-  name: 'strTrim';
-  args: [
-    LiteralValue<string>
-  ];
-};
-
-export interface FstrTrim2 extends FunctionCall<string> {
-  name: 'strTrim2';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<string>,
-    LiteralValue<string>
-  ];
-};
-
-export interface FstrURLEncode extends FunctionCall<string> {
-  name: 'strURLEncode';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<boolean>
-  ];
-};
-
-export interface Ftan extends FunctionCall<number> {
-  name: 'tan';
-  args: [
-    LiteralValue<number>
-  ];
-};
-
-export interface Ftint extends FunctionCall<string> {
-  name: 'tint';
-  args: [
-    LiteralValue<string>,
-    LiteralValue<number>
-  ];
-};
-
-export interface FtoDegrees extends FunctionCall<number> {
-  name: 'toDegrees';
-  args: [
-    LiteralValue<number>
-  ];
-};
-
-export interface FtoRadians extends FunctionCall<number> {
-  name: 'toRadians';
-  args: [
-    LiteralValue<number>
-  ];
-};
-
-export type GeoStylerFunction = Fabs |
+export type GeoStylerNumberFunction = Fabs |
 Fabs_2 |
 Fabs_3 |
 Fabs_4 |
 Facos |
-Farray |
 Fasin |
 Fatan |
 Fatan2 |
-FattributeCount |
-Fbetween |
-FboundedBy |
 Fceil |
-Fclassify |
-Fcontains |
-Fcontrast |
-Fconvert |
 Fcos |
-Fcrosses |
-Fdarken |
-Fdesaturate |
-Fdifference |
-Fdisjoint |
 Fdisjoint3D |
 Fdistance |
 Fdistance3D |
-Fdouble2bool |
 FendAngle |
-FendPoint |
-Fenv |
-FequalsExact |
-FequalsExactTolerance |
-FequalTo |
 Fexp |
 Ffloor |
+Fint2ddouble |
+Fintersects3D |
+FisWithinDistance3D |
+Flength |
+Flog |
+Fmax |
+Fmax_2 |
+Fmax_3 |
+Fmax_4 |
+Fmin |
+Fmin_2 |
+Fmin_3 |
+Fmin_4 |
+Fmodulo |
+FparseDouble |
+FparseInt |
+FparseLong |
+Fpi |
+Fpow |
+Frandom |
+Frint |
+Fround |
+Fround_2 |
+FroundDouble |
+Fsin |
+Fsize |
+Fsqrt |
+FstartAngle |
+FstrIndexOf |
+FstrLastIndexOf |
+FstrLength |
+Ftan |
+FtoDegrees |
+FtoRadians;
+
+export type GeoStylerStringFunction = Farray |
+FattributeCount |
+FboundedBy |
+Fclassify |
+Fcontrast |
+Fconvert |
+Fdarken |
+Fdesaturate |
+Fdifference |
+FendPoint |
+Fenv |
 Fgrayscale |
-FgreaterEqualThan |
-FgreaterThan |
 Fhsl |
 Fid |
 Fif_then_else |
+Fintersection |
+FjsonPointer |
+Flapply |
+Flighten |
+Flist |
+FlistMultiply |
+Flitem |
+Fliterate |
+FmapGet |
+Fmix |
+FnumberFormat |
+FnumberFormat2 |
+Foverlaps |
+Fparameter |
+Fproperty |
+Frelate |
+FrescaleToPixels |
+Fsaturate |
+Fshade |
+Fspin |
+FstartPoint |
+FstrAbbreviate |
+FstrCapitalize |
+FstrConcat |
+FstrDefaultIfBlank |
+FstringTemplate |
+FstrPosition |
+FstrReplace |
+FstrStripAccents |
+FstrSubstring |
+FstrSubstringStart |
+FstrToLowerCase |
+FstrToUpperCase |
+FstrTrim |
+FstrTrim2 |
+FstrURLEncode |
+Ftint;
+
+export type GeoStylerBooleanFunction = Fbetween |
+Fcontains |
+Fcrosses |
+Fdisjoint |
+Fdouble2bool |
+FequalsExact |
+FequalsExactTolerance |
+FequalTo |
+FgreaterEqualThan |
+FgreaterThan |
 Fin |
 Fin10 |
 Fin2 |
@@ -1179,90 +129,1281 @@ Fin8 |
 Fin9 |
 FinArray |
 Fint2bbool |
-Fint2ddouble |
-Fintersection |
 Fintersects |
-Fintersects3D |
 FisCached |
 FisCoverage |
 FisInstanceOf |
 FisLike |
 FisNull |
 FisWithinDistance |
-FisWithinDistance3D |
-FjsonPointer |
-Flapply |
-Flength |
 FlessEqualThan |
 FlessThan |
-Flighten |
-Flist |
-FlistMultiply |
-Flitem |
-Fliterate |
-Flog |
-FmapGet |
-Fmax |
-Fmax_2 |
-Fmax_3 |
-Fmax_4 |
-Fmin |
-Fmin_2 |
-Fmin_3 |
-Fmin_4 |
-Fmix |
-Fmodulo |
 Fnot |
 FnotEqualTo |
-FnumberFormat |
-FnumberFormat2 |
-Foverlaps |
-Fparameter |
 FparseBoolean |
-FparseDouble |
-FparseInt |
-FparseLong |
-Fpi |
-Fpow |
-Fproperty |
-Frandom |
-Frelate |
-FrescaleToPixels |
-Frint |
-Fround |
-Fround_2 |
-FroundDouble |
-Fsaturate |
-Fshade |
-Fsin |
-Fsize |
-Fspin |
-Fsqrt |
-FstartAngle |
-FstartPoint |
-FstrAbbreviate |
-FstrCapitalize |
-FstrConcat |
-FstrDefaultIfBlank |
 FstrEndsWith |
 FstrEqualsIgnoreCase |
-FstrIndexOf |
-FstringTemplate |
-FstrLastIndexOf |
-FstrLength |
 FstrMatches |
-FstrPosition |
-FstrReplace |
-FstrStartsWith |
-FstrStripAccents |
-FstrSubstring |
-FstrSubstringStart |
-FstrToLowerCase |
-FstrToUpperCase |
-FstrTrim |
-FstrTrim2 |
-FstrURLEncode |
-Ftan |
-Ftint |
-FtoDegrees |
-FtoRadians;
+FstrStartsWith;
+
+export interface Fabs extends FunctionCall {
+  type: 'numberfunction';
+  name: 'abs';
+  args: [
+    Expression<number>
+  ];
+};
+
+export interface Fabs_2 extends FunctionCall {
+  type: 'numberfunction';
+  name: 'abs_2';
+  args: [
+    Expression<number>
+  ];
+};
+
+export interface Fabs_3 extends FunctionCall {
+  type: 'numberfunction';
+  name: 'abs_3';
+  args: [
+    Expression<number>
+  ];
+};
+
+export interface Fabs_4 extends FunctionCall {
+  type: 'numberfunction';
+  name: 'abs_4';
+  args: [
+    Expression<number>
+  ];
+};
+
+export interface Facos extends FunctionCall {
+  type: 'numberfunction';
+  name: 'acos';
+  args: [
+    Expression<number>
+  ];
+};
+
+export interface Farray extends FunctionCall {
+  type: 'stringfunction';
+  name: 'array';
+};
+
+export interface Fasin extends FunctionCall {
+  type: 'numberfunction';
+  name: 'asin';
+  args: [
+    Expression<number>
+  ];
+};
+
+export interface Fatan extends FunctionCall {
+  type: 'numberfunction';
+  name: 'atan';
+  args: [
+    Expression<number>
+  ];
+};
+
+export interface Fatan2 extends FunctionCall {
+  type: 'numberfunction';
+  name: 'atan2';
+  args: [
+    Expression<number>,
+    Expression<number>
+  ];
+};
+
+export interface FattributeCount extends FunctionCall {
+  type: 'stringfunction';
+  name: 'attributeCount';
+  args: [
+    Expression<string>
+  ];
+};
+
+export interface Fbetween extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'between';
+  args: [
+    Expression<string>,
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface FboundedBy extends FunctionCall {
+  type: 'stringfunction';
+  name: 'boundedBy';
+};
+
+export interface Fceil extends FunctionCall {
+  type: 'numberfunction';
+  name: 'ceil';
+  args: [
+    Expression<number>
+  ];
+};
+
+export interface Fclassify extends FunctionCall {
+  type: 'stringfunction';
+  name: 'classify';
+  args: [
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface Fcontains extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'contains';
+  args: [
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface Fcontrast extends FunctionCall {
+  type: 'stringfunction';
+  name: 'contrast';
+  args: [
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<number>
+  ];
+};
+
+export interface Fconvert extends FunctionCall {
+  type: 'stringfunction';
+  name: 'convert';
+  args: [
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface Fcos extends FunctionCall {
+  type: 'numberfunction';
+  name: 'cos';
+  args: [
+    Expression<number>
+  ];
+};
+
+export interface Fcrosses extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'crosses';
+  args: [
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface Fdarken extends FunctionCall {
+  type: 'stringfunction';
+  name: 'darken';
+  args: [
+    Expression<string>,
+    Expression<number>,
+    Expression<string>
+  ];
+};
+
+export interface Fdesaturate extends FunctionCall {
+  type: 'stringfunction';
+  name: 'desaturate';
+  args: [
+    Expression<string>,
+    Expression<number>,
+    Expression<string>
+  ];
+};
+
+export interface Fdifference extends FunctionCall {
+  type: 'stringfunction';
+  name: 'difference';
+  args: [
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface Fdisjoint extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'disjoint';
+  args: [
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface Fdisjoint3D extends FunctionCall {
+  type: 'numberfunction';
+  name: 'disjoint3D';
+  args: [
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface Fdistance extends FunctionCall {
+  type: 'numberfunction';
+  name: 'distance';
+  args: [
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface Fdistance3D extends FunctionCall {
+  type: 'numberfunction';
+  name: 'distance3D';
+  args: [
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface Fdouble2bool extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'double2bool';
+  args: [
+    Expression<number>
+  ];
+};
+
+export interface FendAngle extends FunctionCall {
+  type: 'numberfunction';
+  name: 'endAngle';
+  args: [
+    Expression<string>
+  ];
+};
+
+export interface FendPoint extends FunctionCall {
+  type: 'stringfunction';
+  name: 'endPoint';
+  args: [
+    Expression<string>
+  ];
+};
+
+export interface Fenv extends FunctionCall {
+  type: 'stringfunction';
+  name: 'env';
+  args: [
+    Expression<string>
+  ];
+};
+
+export interface FequalsExact extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'equalsExact';
+  args: [
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface FequalsExactTolerance extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'equalsExactTolerance';
+  args: [
+    Expression<string>,
+    Expression<string>,
+    Expression<number>
+  ];
+};
+
+export interface FequalTo extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'equalTo';
+  args: [
+    Expression<string>,
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface Fexp extends FunctionCall {
+  type: 'numberfunction';
+  name: 'exp';
+  args: [
+    Expression<number>
+  ];
+};
+
+export interface Ffloor extends FunctionCall {
+  type: 'numberfunction';
+  name: 'floor';
+  args: [
+    Expression<number>
+  ];
+};
+
+export interface Fgrayscale extends FunctionCall {
+  type: 'stringfunction';
+  name: 'grayscale';
+  args: [
+    Expression<string>
+  ];
+};
+
+export interface FgreaterEqualThan extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'greaterEqualThan';
+  args: [
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface FgreaterThan extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'greaterThan';
+  args: [
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface Fhsl extends FunctionCall {
+  type: 'stringfunction';
+  name: 'hsl';
+  args: [
+    Expression<number>,
+    Expression<number>,
+    Expression<number>
+  ];
+};
+
+export interface Fid extends FunctionCall {
+  type: 'stringfunction';
+  name: 'id';
+};
+
+export interface Fif_then_else extends FunctionCall {
+  type: 'stringfunction';
+  name: 'if_then_else';
+  args: [
+    Expression<boolean>,
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface Fin extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'in';
+  args: [
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface Fin10 extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'in10';
+  args: [
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface Fin2 extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'in2';
+  args: [
+    Expression<string>,
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface Fin3 extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'in3';
+  args: [
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface Fin4 extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'in4';
+  args: [
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface Fin5 extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'in5';
+  args: [
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface Fin6 extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'in6';
+  args: [
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface Fin7 extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'in7';
+  args: [
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface Fin8 extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'in8';
+  args: [
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface Fin9 extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'in9';
+  args: [
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface FinArray extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'inArray';
+  args: [
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface Fint2bbool extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'int2bbool';
+  args: [
+    Expression<number>
+  ];
+};
+
+export interface Fint2ddouble extends FunctionCall {
+  type: 'numberfunction';
+  name: 'int2ddouble';
+  args: [
+    Expression<number>
+  ];
+};
+
+export interface Fintersection extends FunctionCall {
+  type: 'stringfunction';
+  name: 'intersection';
+  args: [
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface Fintersects extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'intersects';
+  args: [
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface Fintersects3D extends FunctionCall {
+  type: 'numberfunction';
+  name: 'intersects3D';
+  args: [
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface FisCached extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'isCached';
+  args: [
+    Expression<string>
+  ];
+};
+
+export interface FisCoverage extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'isCoverage';
+};
+
+export interface FisInstanceOf extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'isInstanceOf';
+  args: [
+    Expression<string>
+  ];
+};
+
+export interface FisLike extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'isLike';
+  args: [
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface FisNull extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'isNull';
+  args: [
+    Expression<string>
+  ];
+};
+
+export interface FisWithinDistance extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'isWithinDistance';
+  args: [
+    Expression<string>,
+    Expression<string>,
+    Expression<number>
+  ];
+};
+
+export interface FisWithinDistance3D extends FunctionCall {
+  type: 'numberfunction';
+  name: 'isWithinDistance3D';
+  args: [
+    Expression<string>,
+    Expression<string>,
+    Expression<number>
+  ];
+};
+
+export interface FjsonPointer extends FunctionCall {
+  type: 'stringfunction';
+  name: 'jsonPointer';
+  args: [
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface Flapply extends FunctionCall {
+  type: 'stringfunction';
+  name: 'lapply';
+  args: [
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface Flength extends FunctionCall {
+  type: 'numberfunction';
+  name: 'length';
+  args: [
+    Expression<string>
+  ];
+};
+
+export interface FlessEqualThan extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'lessEqualThan';
+  args: [
+    Expression<number>,
+    Expression<number>
+  ];
+};
+
+export interface FlessThan extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'lessThan';
+  args: [
+    Expression<number>,
+    Expression<number>
+  ];
+};
+
+export interface Flighten extends FunctionCall {
+  type: 'stringfunction';
+  name: 'lighten';
+  args: [
+    Expression<string>,
+    Expression<number>,
+    Expression<string>
+  ];
+};
+
+export interface Flist extends FunctionCall {
+  type: 'stringfunction';
+  name: 'list';
+  args: [
+    Expression<string>
+  ];
+};
+
+export interface FlistMultiply extends FunctionCall {
+  type: 'stringfunction';
+  name: 'listMultiply';
+  args: [
+    Expression<number>,
+    Expression<string>
+  ];
+};
+
+export interface Flitem extends FunctionCall {
+  type: 'stringfunction';
+  name: 'litem';
+  args: [
+    Expression<string>,
+    Expression<number>
+  ];
+};
+
+export interface Fliterate extends FunctionCall {
+  type: 'stringfunction';
+  name: 'literate';
+  args: [
+    Expression<string>,
+    Expression<number>,
+    Expression<string>
+  ];
+};
+
+export interface Flog extends FunctionCall {
+  type: 'numberfunction';
+  name: 'log';
+  args: [
+    Expression<number>
+  ];
+};
+
+export interface FmapGet extends FunctionCall {
+  type: 'stringfunction';
+  name: 'mapGet';
+  args: [
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface Fmax extends FunctionCall {
+  type: 'numberfunction';
+  name: 'max';
+  args: [
+    Expression<number>,
+    Expression<number>
+  ];
+};
+
+export interface Fmax_2 extends FunctionCall {
+  type: 'numberfunction';
+  name: 'max_2';
+  args: [
+    Expression<number>,
+    Expression<number>
+  ];
+};
+
+export interface Fmax_3 extends FunctionCall {
+  type: 'numberfunction';
+  name: 'max_3';
+  args: [
+    Expression<number>,
+    Expression<number>
+  ];
+};
+
+export interface Fmax_4 extends FunctionCall {
+  type: 'numberfunction';
+  name: 'max_4';
+  args: [
+    Expression<number>,
+    Expression<number>
+  ];
+};
+
+export interface Fmin extends FunctionCall {
+  type: 'numberfunction';
+  name: 'min';
+  args: [
+    Expression<number>,
+    Expression<number>
+  ];
+};
+
+export interface Fmin_2 extends FunctionCall {
+  type: 'numberfunction';
+  name: 'min_2';
+  args: [
+    Expression<number>,
+    Expression<number>
+  ];
+};
+
+export interface Fmin_3 extends FunctionCall {
+  type: 'numberfunction';
+  name: 'min_3';
+  args: [
+    Expression<number>,
+    Expression<number>
+  ];
+};
+
+export interface Fmin_4 extends FunctionCall {
+  type: 'numberfunction';
+  name: 'min_4';
+  args: [
+    Expression<number>,
+    Expression<number>
+  ];
+};
+
+export interface Fmix extends FunctionCall {
+  type: 'stringfunction';
+  name: 'mix';
+  args: [
+    Expression<string>,
+    Expression<string>,
+    Expression<number>
+  ];
+};
+
+export interface Fmodulo extends FunctionCall {
+  type: 'numberfunction';
+  name: 'modulo';
+  args: [
+    Expression<number>,
+    Expression<number>
+  ];
+};
+
+export interface Fnot extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'not';
+  args: [
+    Expression<boolean>
+  ];
+};
+
+export interface FnotEqualTo extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'notEqualTo';
+  args: [
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface FnumberFormat extends FunctionCall {
+  type: 'stringfunction';
+  name: 'numberFormat';
+  args: [
+    Expression<string>,
+    Expression<number>,
+    Expression<string>
+  ];
+};
+
+export interface FnumberFormat2 extends FunctionCall {
+  type: 'stringfunction';
+  name: 'numberFormat2';
+  args: [
+    Expression<string>,
+    Expression<number>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface Foverlaps extends FunctionCall {
+  type: 'stringfunction';
+  name: 'overlaps';
+  args: [
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface Fparameter extends FunctionCall {
+  type: 'stringfunction';
+  name: 'parameter';
+  args: [
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface FparseBoolean extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'parseBoolean';
+  args: [
+    Expression<string>
+  ];
+};
+
+export interface FparseDouble extends FunctionCall {
+  type: 'numberfunction';
+  name: 'parseDouble';
+  args: [
+    Expression<string>
+  ];
+};
+
+export interface FparseInt extends FunctionCall {
+  type: 'numberfunction';
+  name: 'parseInt';
+  args: [
+    Expression<string>
+  ];
+};
+
+export interface FparseLong extends FunctionCall {
+  type: 'numberfunction';
+  name: 'parseLong';
+  args: [
+    Expression<string>
+  ];
+};
+
+export interface Fpi extends FunctionCall {
+  type: 'numberfunction';
+  name: 'pi';
+};
+
+export interface Fpow extends FunctionCall {
+  type: 'numberfunction';
+  name: 'pow';
+  args: [
+    Expression<number>,
+    Expression<number>
+  ];
+};
+
+export interface Fproperty extends FunctionCall {
+  type: 'stringfunction';
+  name: 'property';
+  args: [
+    Expression<string>
+  ];
+};
+
+export interface Frandom extends FunctionCall {
+  type: 'numberfunction';
+  name: 'random';
+};
+
+export interface Frelate extends FunctionCall {
+  type: 'stringfunction';
+  name: 'relate';
+  args: [
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface FrescaleToPixels extends FunctionCall {
+  type: 'stringfunction';
+  name: 'rescaleToPixels';
+  args: [
+    Expression<string>,
+    Expression<string>,
+    Expression<number>,
+    Expression<string>
+  ];
+};
+
+export interface Frint extends FunctionCall {
+  type: 'numberfunction';
+  name: 'rint';
+  args: [
+    Expression<number>
+  ];
+};
+
+export interface Fround extends FunctionCall {
+  type: 'numberfunction';
+  name: 'round';
+  args: [
+    Expression<number>
+  ];
+};
+
+export interface Fround_2 extends FunctionCall {
+  type: 'numberfunction';
+  name: 'round_2';
+  args: [
+    Expression<number>
+  ];
+};
+
+export interface FroundDouble extends FunctionCall {
+  type: 'numberfunction';
+  name: 'roundDouble';
+  args: [
+    Expression<number>
+  ];
+};
+
+export interface Fsaturate extends FunctionCall {
+  type: 'stringfunction';
+  name: 'saturate';
+  args: [
+    Expression<string>,
+    Expression<number>,
+    Expression<string>
+  ];
+};
+
+export interface Fshade extends FunctionCall {
+  type: 'stringfunction';
+  name: 'shade';
+  args: [
+    Expression<string>,
+    Expression<number>
+  ];
+};
+
+export interface Fsin extends FunctionCall {
+  type: 'numberfunction';
+  name: 'sin';
+  args: [
+    Expression<number>
+  ];
+};
+
+export interface Fsize extends FunctionCall {
+  type: 'numberfunction';
+  name: 'size';
+  args: [
+    Expression<string>
+  ];
+};
+
+export interface Fspin extends FunctionCall {
+  type: 'stringfunction';
+  name: 'spin';
+  args: [
+    Expression<string>,
+    Expression<number>
+  ];
+};
+
+export interface Fsqrt extends FunctionCall {
+  type: 'numberfunction';
+  name: 'sqrt';
+  args: [
+    Expression<number>
+  ];
+};
+
+export interface FstartAngle extends FunctionCall {
+  type: 'numberfunction';
+  name: 'startAngle';
+  args: [
+    Expression<string>
+  ];
+};
+
+export interface FstartPoint extends FunctionCall {
+  type: 'stringfunction';
+  name: 'startPoint';
+  args: [
+    Expression<string>
+  ];
+};
+
+export interface FstrAbbreviate extends FunctionCall {
+  type: 'stringfunction';
+  name: 'strAbbreviate';
+  args: [
+    Expression<string>,
+    Expression<number>,
+    Expression<number>,
+    Expression<string>
+  ];
+};
+
+export interface FstrCapitalize extends FunctionCall {
+  type: 'stringfunction';
+  name: 'strCapitalize';
+  args: [
+    Expression<string>
+  ];
+};
+
+export interface FstrConcat extends FunctionCall {
+  type: 'stringfunction';
+  name: 'strConcat';
+  args: [
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface FstrDefaultIfBlank extends FunctionCall {
+  type: 'stringfunction';
+  name: 'strDefaultIfBlank';
+  args: [
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface FstrEndsWith extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'strEndsWith';
+  args: [
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface FstrEqualsIgnoreCase extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'strEqualsIgnoreCase';
+  args: [
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface FstrIndexOf extends FunctionCall {
+  type: 'numberfunction';
+  name: 'strIndexOf';
+  args: [
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface FstringTemplate extends FunctionCall {
+  type: 'stringfunction';
+  name: 'stringTemplate';
+  args: [
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface FstrLastIndexOf extends FunctionCall {
+  type: 'numberfunction';
+  name: 'strLastIndexOf';
+  args: [
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface FstrLength extends FunctionCall{
+  type: 'numberfunction';
+  name: 'strLength';
+  args: [
+    Expression<string>
+  ];
+};
+
+export interface FstrMatches extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'strMatches';
+  args: [
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface FstrPosition extends FunctionCall {
+  type: 'stringfunction';
+  name: 'strPosition';
+  args: [
+    Expression<string>,
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface FstrReplace extends FunctionCall {
+  type: 'stringfunction';
+  name: 'strReplace';
+  args: [
+    Expression<string>,
+    Expression<string>,
+    Expression<string>,
+    Expression<boolean>
+  ];
+};
+
+export interface FstrStartsWith extends FunctionCall {
+  type: 'booleanfunction';
+  name: 'strStartsWith';
+  args: [
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface FstrStripAccents extends FunctionCall {
+  type: 'stringfunction';
+  name: 'strStripAccents';
+  args: [
+    Expression<string>
+  ];
+};
+
+export interface FstrSubstring extends FunctionCall {
+  type: 'stringfunction';
+  name: 'strSubstring';
+  args: [
+    Expression<string>,
+    Expression<number>,
+    Expression<number>
+  ];
+};
+
+export interface FstrSubstringStart extends FunctionCall {
+  type: 'stringfunction';
+  name: 'strSubstringStart';
+  args: [
+    Expression<string>,
+    Expression<number>
+  ];
+};
+
+export interface FstrToLowerCase extends FunctionCall {
+  type: 'stringfunction';
+  name: 'strToLowerCase';
+  args: [
+    Expression<string>
+  ];
+};
+
+export interface FstrToUpperCase extends FunctionCall {
+  type: 'stringfunction';
+  name: 'strToUpperCase';
+  args: [
+    Expression<string>
+  ];
+};
+
+export interface FstrTrim extends FunctionCall {
+  type: 'stringfunction';
+  name: 'strTrim';
+  args: [
+    Expression<string>
+  ];
+};
+
+export interface FstrTrim2 extends FunctionCall {
+  type: 'stringfunction';
+  name: 'strTrim2';
+  args: [
+    Expression<string>,
+    Expression<string>,
+    Expression<string>
+  ];
+};
+
+export interface FstrURLEncode extends FunctionCall {
+  type: 'stringfunction';
+  name: 'strURLEncode';
+  args: [
+    Expression<string>,
+    Expression<boolean>
+  ];
+};
+
+export interface Ftan extends FunctionCall {
+  type: 'numberfunction';
+  name: 'tan';
+  args: [
+    Expression<number>
+  ];
+};
+
+export interface Ftint extends FunctionCall {
+  type: 'stringfunction';
+  name: 'tint';
+  args: [
+    Expression<string>,
+    Expression<number>
+  ];
+};
+
+export interface FtoDegrees extends FunctionCall {
+  type: 'numberfunction';
+  name: 'toDegrees';
+  args: [
+    Expression<number>
+  ];
+};
+
+export interface FtoRadians extends FunctionCall {
+  type: 'numberfunction';
+  name: 'toRadians';
+  args: [
+    Expression<number>
+  ];
+};

--- a/functions.ts
+++ b/functions.ts
@@ -4,6 +4,10 @@ import {
   Expression
 } from './style';
 
+export type GeoStylerFunction = GeoStylerNumberFunction |
+  GeoStylerStringFunction |
+  GeoStylerBooleanFunction;
+
 export type GeoStylerNumberFunction = Fabs |
 Facos |
 Fasin |
@@ -54,13 +58,10 @@ FstrEqualsIgnoreCase |
 FstrMatches |
 FstrStartsWith;
 
-export type GeoStylerVoidFunction = unknown;
-
 /**
  * The absolute value of the specified number value
  */
 export interface Fabs extends FunctionCall<number> {
-  type: 'numberfunction';
   name: 'abs';
   args: [
     Expression<number>
@@ -71,7 +72,6 @@ export interface Fabs extends FunctionCall<number> {
  * Returns the arc cosine of an angle in radians, in the range of 0.0 through PI
  */
 export interface Facos extends FunctionCall<number> {
-  type: 'numberfunction';
   name: 'acos';
   args: [
     Expression<number>
@@ -82,7 +82,6 @@ export interface Facos extends FunctionCall<number> {
  * Returns the arc sine of an angle in radians, in the range of -PI / 2 through PI / 2
  */
 export interface Fasin extends FunctionCall<number> {
-  type: 'numberfunction';
   name: 'asin';
   args: [
     Expression<number>
@@ -93,7 +92,6 @@ export interface Fasin extends FunctionCall<number> {
  * Returns the arc tangent of an angle in radians, in the range of -PI/2 through PI/2
  */
 export interface Fatan extends FunctionCall<number> {
-  type: 'numberfunction';
   name: 'atan';
   args: [
     Expression<number>
@@ -104,7 +102,6 @@ export interface Fatan extends FunctionCall<number> {
  * Converts a rectangular coordinate (x, y) to polar (r, theta) and returns theta.
  */
 export interface Fatan2 extends FunctionCall<number> {
-  type: 'numberfunction';
   name: 'atan2';
   args: [
     Expression<number>,
@@ -116,7 +113,6 @@ export interface Fatan2 extends FunctionCall<number> {
  * Returns true if arg1 <= arg0 <= arg2
  */
 export interface Fbetween extends FunctionCall<boolean> {
-  type: 'booleanfunction';
   name: 'between';
   args: [
     Expression<string>,
@@ -130,7 +126,6 @@ export interface Fbetween extends FunctionCall<boolean> {
  * x and is equal to a mathematical integer.
  */
 export interface Fceil extends FunctionCall<number> {
-  type: 'numberfunction';
   name: 'ceil';
   args: [
     Expression<number>
@@ -141,7 +136,6 @@ export interface Fceil extends FunctionCall<number> {
  * Returns the cosine of an angle expressed in radians
  */
 export interface Fcos extends FunctionCall<number> {
-  type: 'numberfunction';
   name: 'cos';
   args: [
     Expression<number>
@@ -152,7 +146,6 @@ export interface Fcos extends FunctionCall<number> {
  * Returns true if x is zero, false otherwise
  */
 export interface Fdouble2bool extends FunctionCall<boolean> {
-  type: 'booleanfunction';
   name: 'double2bool';
   args: [
     Expression<number>
@@ -163,7 +156,6 @@ export interface Fdouble2bool extends FunctionCall<boolean> {
  * Returns Euler’s number e raised to the power of x
  */
 export interface Fexp extends FunctionCall<number> {
-  type: 'numberfunction';
   name: 'exp';
   args: [
     Expression<number>
@@ -175,7 +167,6 @@ export interface Fexp extends FunctionCall<number> {
  * equal to a mathematical integer
  */
 export interface Ffloor extends FunctionCall<number> {
-  type: 'numberfunction';
   name: 'floor';
   args: [
     Expression<number>
@@ -187,7 +178,6 @@ export interface Ffloor extends FunctionCall<number> {
  * function name matching the number of arguments specified.
  */
 export interface Fin extends FunctionCall<boolean> {
-  type: 'booleanfunction';
   name: 'in';
   args: Expression<string>[];
 };
@@ -196,7 +186,6 @@ export interface Fin extends FunctionCall<boolean> {
  * Returns the natural logarithm (base e) of x
  */
 export interface Flog extends FunctionCall<number> {
-  type: 'numberfunction';
   name: 'log';
   args: [
     Expression<number>
@@ -207,7 +196,6 @@ export interface Flog extends FunctionCall<number> {
  * Returns the maximum between argument[0], …, argument[n]
  */
 export interface Fmax extends FunctionCall<number> {
-  type: 'numberfunction';
   name: 'max';
   args: Expression<number>[];
 };
@@ -216,13 +204,11 @@ export interface Fmax extends FunctionCall<number> {
  * Returns the minimum between argument[0], …, argument[n]
  */
 export interface Fmin extends FunctionCall<number> {
-  type: 'numberfunction';
   name: 'min';
   args: Expression<number>[];
 };
 
 export interface Fmodulo extends FunctionCall<number> {
-  type: 'numberfunction';
   name: 'modulo';
   args: [
     Expression<number>,
@@ -236,7 +222,6 @@ export interface Fmodulo extends FunctionCall<number> {
  * in the Java DecimalFormat javadocs
  */
 export interface FnumberFormat extends FunctionCall<string> {
-  type: 'stringfunction';
   name: 'numberFormat';
   args: [
     Expression<string>,
@@ -250,7 +235,6 @@ export interface FnumberFormat extends FunctionCall<string> {
  * else is considered true.
  */
 export interface FparseBoolean extends FunctionCall<boolean> {
-  type: 'booleanfunction';
   name: 'parseBoolean';
   args: [
     Expression<string>
@@ -261,7 +245,6 @@ export interface FparseBoolean extends FunctionCall<boolean> {
  * Returns an approximation of pi, the ratio of the circumference of a circle to its diameter
  */
 export interface Fpi extends FunctionCall<number> {
-  type: 'numberfunction';
   name: 'pi';
 };
 
@@ -269,7 +252,6 @@ export interface Fpi extends FunctionCall<number> {
  * Returns the value of base (argument[0]) raised to the power of exponent (arguments[1])
  */
 export interface Fpow extends FunctionCall<number> {
-  type: 'numberfunction';
   name: 'pow';
   args: [
     Expression<number>,
@@ -279,10 +261,9 @@ export interface Fpow extends FunctionCall<number> {
 
 /**
  * Returns the value of the property propertyName. Allows property names to be compute
- *  or specified by Variable substitution in SLD.
+ * or specified by Variable substitution in SLD.
  */
 export interface Fproperty extends FunctionCall<string> {
-  type: 'stringfunction';
   name: 'property';
   args: [
     Expression<string>
@@ -293,7 +274,6 @@ export interface Fproperty extends FunctionCall<string> {
  * Returns a Double value with a positive sign, greater than or equal to 0.0 and less than 1.0.
  */
 export interface Frandom extends FunctionCall<number> {
-  type: 'numberfunction';
   name: 'random';
 };
 
@@ -303,7 +283,6 @@ export interface Frandom extends FunctionCall<number> {
  * integer value that is even.
  */
 export interface Frint extends FunctionCall<number> {
-  type: 'numberfunction';
   name: 'rint';
   args: [
     Expression<number>
@@ -314,7 +293,6 @@ export interface Frint extends FunctionCall<number> {
  * Returns the closest number to argument[0].
  */
 export interface Fround extends FunctionCall<number> {
-  type: 'numberfunction';
   name: 'round';
   args: [
     Expression<number>
@@ -325,7 +303,6 @@ export interface Fround extends FunctionCall<number> {
  * Returns the sine of an angle expressed in radians
  */
 export interface Fsin extends FunctionCall<number> {
-  type: 'numberfunction';
   name: 'sin';
   args: [
     Expression<number>
@@ -336,7 +313,6 @@ export interface Fsin extends FunctionCall<number> {
  * Returns the square root of argument[0]
  */
 export interface Fsqrt extends FunctionCall<number> {
-  type: 'numberfunction';
   name: 'sqrt';
   args: [
     Expression<number>
@@ -348,7 +324,6 @@ export interface Fsqrt extends FunctionCall<number> {
  * or at upper (argument[2]) if no space.Appends append (argument[3]) if string is abbreviated.
  */
 export interface FstrAbbreviate extends FunctionCall<string> {
-  type: 'stringfunction';
   name: 'strAbbreviate';
   args: [
     Expression<string>,
@@ -362,7 +337,6 @@ export interface FstrAbbreviate extends FunctionCall<string> {
  * Fully capitalizes the sentence. For example, “HoW aRe YOU?” will be turned into “How Are You?”
  */
 export interface FstrCapitalize extends FunctionCall<string> {
-  type: 'stringfunction';
   name: 'strCapitalize';
   args: [
     Expression<string>
@@ -373,7 +347,6 @@ export interface FstrCapitalize extends FunctionCall<string> {
  * Concatenates the two strings into one
  */
 export interface FstrConcat extends FunctionCall<string> {
-  type: 'stringfunction';
   name: 'strConcat';
   args: [
     Expression<string>,
@@ -385,7 +358,6 @@ export interface FstrConcat extends FunctionCall<string> {
  * Returns default (argument[1]) if str (argument[0]) is empty, blank or null
  */
 export interface FstrDefaultIfBlank extends FunctionCall<string> {
-  type: 'stringfunction';
   name: 'strDefaultIfBlank';
   args: [
     Expression<string>,
@@ -397,7 +369,6 @@ export interface FstrDefaultIfBlank extends FunctionCall<string> {
  * Returns true if string (argument[0]) ends with suffix (argument[1])
   */
 export interface FstrEndsWith extends FunctionCall<boolean> {
-  type: 'booleanfunction';
   name: 'strEndsWith';
   args: [
     Expression<string>,
@@ -409,7 +380,6 @@ export interface FstrEndsWith extends FunctionCall<boolean> {
  * Returns true if the two strings are equal ignoring case considerations
  */
 export interface FstrEqualsIgnoreCase extends FunctionCall<boolean> {
-  type: 'booleanfunction';
   name: 'strEqualsIgnoreCase';
   args: [
     Expression<string>,
@@ -422,7 +392,6 @@ export interface FstrEqualsIgnoreCase extends FunctionCall<boolean> {
  * substring (argument[1]), or -1 if not found
  */
 export interface FstrIndexOf extends FunctionCall<number> {
-  type: 'numberfunction';
   name: 'strIndexOf';
   args: [
     Expression<string>,
@@ -435,7 +404,6 @@ export interface FstrIndexOf extends FunctionCall<number> {
  * substring (arguments[1]), or -1 if not found
  */
 export interface FstrLastIndexOf extends FunctionCall<number> {
-  type: 'numberfunction';
   name: 'strLastIndexOf';
   args: [
     Expression<string>,
@@ -447,7 +415,6 @@ export interface FstrLastIndexOf extends FunctionCall<number> {
  * Returns the string length
  */
 export interface FstrLength extends FunctionCall<number>{
-  type: 'numberfunction';
   name: 'strLength';
   args: [
     Expression<string>
@@ -459,7 +426,6 @@ export interface FstrLength extends FunctionCall<number>{
  * For the full syntax of the pattern specification see the Java Pattern class javadocs
  */
 export interface FstrMatches extends FunctionCall<boolean> {
-  type: 'booleanfunction';
   name: 'strMatches';
   args: [
     Expression<string>,
@@ -474,7 +440,6 @@ export interface FstrMatches extends FunctionCall<boolean> {
  * the Java Pattern class javadocs
  */
 export interface FstrReplace extends FunctionCall<string> {
-  type: 'stringfunction';
   name: 'strReplace';
   args: [
     Expression<string>,
@@ -488,7 +453,6 @@ export interface FstrReplace extends FunctionCall<string> {
  * Returns true if string (argument[0]) starts with prefix (argument[1]).
  */
 export interface FstrStartsWith extends FunctionCall<boolean> {
-  type: 'booleanfunction';
   name: 'strStartsWith';
   args: [
     Expression<string>,
@@ -500,7 +464,6 @@ export interface FstrStartsWith extends FunctionCall<boolean> {
  * Removes diacritics (~= accents) from a string. The case will not be altered.
  */
 export interface FstrStripAccents extends FunctionCall<string> {
-  type: 'stringfunction';
   name: 'strStripAccents';
   args: [
     Expression<string>
@@ -513,7 +476,6 @@ export interface FstrStripAccents extends FunctionCall<string> {
  * (indexes are zero-based).
  */
 export interface FstrSubstring extends FunctionCall<string> {
-  type: 'stringfunction';
   name: 'strSubstring';
   args: [
     Expression<string>,
@@ -527,7 +489,6 @@ export interface FstrSubstring extends FunctionCall<string> {
  * at the specified begin (arguments[1]) and extends to the last character of the string
  */
 export interface FstrSubstringStart extends FunctionCall<string> {
-  type: 'stringfunction';
   name: 'strSubstringStart';
   args: [
     Expression<string>,
@@ -539,7 +500,6 @@ export interface FstrSubstringStart extends FunctionCall<string> {
  * Returns the lower case version of the string
  */
 export interface FstrToLowerCase extends FunctionCall<string> {
-  type: 'stringfunction';
   name: 'strToLowerCase';
   args: [
     Expression<string>
@@ -550,7 +510,6 @@ export interface FstrToLowerCase extends FunctionCall<string> {
  * Returns the upper case version of the string
  */
 export interface FstrToUpperCase extends FunctionCall<string> {
-  type: 'stringfunction';
   name: 'strToUpperCase';
   args: [
     Expression<string>
@@ -561,7 +520,6 @@ export interface FstrToUpperCase extends FunctionCall<string> {
  * Returns a copy of the string, with leading and trailing blank-space omitted
  */
 export interface FstrTrim extends FunctionCall<string> {
-  type: 'stringfunction';
   name: 'strTrim';
   args: [
     Expression<string>
@@ -572,7 +530,6 @@ export interface FstrTrim extends FunctionCall<string> {
  * Returns the trigonometric tangent of angle expressed in radians
  */
 export interface Ftan extends FunctionCall<number> {
-  type: 'numberfunction';
   name: 'tan';
   args: [
     Expression<number>
@@ -583,7 +540,6 @@ export interface Ftan extends FunctionCall<number> {
  * Converts an angle expressed in radians into degrees
  */
 export interface FtoDegrees extends FunctionCall<number> {
-  type: 'numberfunction';
   name: 'toDegrees';
   args: [
     Expression<number>
@@ -594,7 +550,6 @@ export interface FtoDegrees extends FunctionCall<number> {
  * Converts an angle expressed in radians into degrees
  */
 export interface FtoRadians extends FunctionCall<number> {
-  type: 'numberfunction';
   name: 'toRadians';
   args: [
     Expression<number>

--- a/functions.ts
+++ b/functions.ts
@@ -265,7 +265,7 @@ export interface Fpow extends FunctionCall<number> {
 };
 
 /**
- * Returns the value of the property propertyName. Allows property names to be compute
+ * Returns the value of the property argument[0]. Allows property names to be compute
  * or specified by Variable substitution in SLD.
  */
 export interface Fproperty extends FunctionCall<unknown> {

--- a/functions.ts
+++ b/functions.ts
@@ -1,0 +1,1268 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import {
+  FunctionCall,
+  LiteralValue
+} from './style';
+
+export interface Fabs extends FunctionCall<number> {
+  name: 'abs';
+  args: [
+    LiteralValue<number>
+  ];
+};
+
+export interface Fabs_2 extends FunctionCall<number> {
+  name: 'abs_2';
+  args: [
+    LiteralValue<number>
+  ];
+};
+
+export interface Fabs_3 extends FunctionCall<number> {
+  name: 'abs_3';
+  args: [
+    LiteralValue<number>
+  ];
+};
+
+export interface Fabs_4 extends FunctionCall<number> {
+  name: 'abs_4';
+  args: [
+    LiteralValue<number>
+  ];
+};
+
+export interface Facos extends FunctionCall<number> {
+  name: 'acos';
+  args: [
+    LiteralValue<number>
+  ];
+};
+
+export interface Farray extends FunctionCall<string> {
+  name: 'array';
+};
+
+export interface Fasin extends FunctionCall<number> {
+  name: 'asin';
+  args: [
+    LiteralValue<number>
+  ];
+};
+
+export interface Fatan extends FunctionCall<number> {
+  name: 'atan';
+  args: [
+    LiteralValue<number>
+  ];
+};
+
+export interface Fatan2 extends FunctionCall<number> {
+  name: 'atan2';
+  args: [
+    LiteralValue<number>,
+    LiteralValue<number>
+  ];
+};
+
+export interface FattributeCount extends FunctionCall<string> {
+  name: 'attributeCount';
+  args: [
+    LiteralValue<string>
+  ];
+};
+
+export interface Fbetween extends FunctionCall<boolean> {
+  name: 'between';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface FboundedBy extends FunctionCall<string> {
+  name: 'boundedBy';
+};
+
+export interface Fceil extends FunctionCall<number> {
+  name: 'ceil';
+  args: [
+    LiteralValue<number>
+  ];
+};
+
+export interface Fclassify extends FunctionCall<string> {
+  name: 'classify';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Fcontains extends FunctionCall<boolean> {
+  name: 'contains';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Fcontrast extends FunctionCall<string> {
+  name: 'contrast';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<number>
+  ];
+};
+
+export interface Fconvert extends FunctionCall<string> {
+  name: 'convert';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Fcos extends FunctionCall<number> {
+  name: 'cos';
+  args: [
+    LiteralValue<number>
+  ];
+};
+
+export interface Fcrosses extends FunctionCall<boolean> {
+  name: 'crosses';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Fdarken extends FunctionCall<string> {
+  name: 'darken';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<number>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Fdesaturate extends FunctionCall<string> {
+  name: 'desaturate';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<number>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Fdifference extends FunctionCall<string> {
+  name: 'difference';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Fdisjoint extends FunctionCall<boolean> {
+  name: 'disjoint';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Fdisjoint3D extends FunctionCall<number> {
+  name: 'disjoint3D';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Fdistance extends FunctionCall<number> {
+  name: 'distance';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Fdistance3D extends FunctionCall<number> {
+  name: 'distance3D';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Fdouble2bool extends FunctionCall<boolean> {
+  name: 'double2bool';
+  args: [
+    LiteralValue<number>
+  ];
+};
+
+export interface FendAngle extends FunctionCall<number> {
+  name: 'endAngle';
+  args: [
+    LiteralValue<string>
+  ];
+};
+
+export interface FendPoint extends FunctionCall<string> {
+  name: 'endPoint';
+  args: [
+    LiteralValue<string>
+  ];
+};
+
+export interface Fenv extends FunctionCall<string> {
+  name: 'env';
+  args: [
+    LiteralValue<string>
+  ];
+};
+
+export interface FequalsExact extends FunctionCall<boolean> {
+  name: 'equalsExact';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface FequalsExactTolerance extends FunctionCall<boolean> {
+  name: 'equalsExactTolerance';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<number>
+  ];
+};
+
+export interface FequalTo extends FunctionCall<boolean> {
+  name: 'equalTo';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Fexp extends FunctionCall<number> {
+  name: 'exp';
+  args: [
+    LiteralValue<number>
+  ];
+};
+
+export interface Ffloor extends FunctionCall<number> {
+  name: 'floor';
+  args: [
+    LiteralValue<number>
+  ];
+};
+
+export interface Fgrayscale extends FunctionCall<string> {
+  name: 'grayscale';
+  args: [
+    LiteralValue<string>
+  ];
+};
+
+export interface FgreaterEqualThan extends FunctionCall<boolean> {
+  name: 'greaterEqualThan';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface FgreaterThan extends FunctionCall<boolean> {
+  name: 'greaterThan';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Fhsl extends FunctionCall<string> {
+  name: 'hsl';
+  args: [
+    LiteralValue<number>,
+    LiteralValue<number>,
+    LiteralValue<number>
+  ];
+};
+
+export interface Fid extends FunctionCall<string> {
+  name: 'id';
+};
+
+export interface Fif_then_else extends FunctionCall<string> {
+  name: 'if_then_else';
+  args: [
+    LiteralValue<boolean>,
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Fin extends FunctionCall<boolean> {
+  name: 'in';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Fin10 extends FunctionCall<boolean> {
+  name: 'in10';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Fin2 extends FunctionCall<boolean> {
+  name: 'in2';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Fin3 extends FunctionCall<boolean> {
+  name: 'in3';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Fin4 extends FunctionCall<boolean> {
+  name: 'in4';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Fin5 extends FunctionCall<boolean> {
+  name: 'in5';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Fin6 extends FunctionCall<boolean> {
+  name: 'in6';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Fin7 extends FunctionCall<boolean> {
+  name: 'in7';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Fin8 extends FunctionCall<boolean> {
+  name: 'in8';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Fin9 extends FunctionCall<boolean> {
+  name: 'in9';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface FinArray extends FunctionCall<boolean> {
+  name: 'inArray';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Fint2bbool extends FunctionCall<boolean> {
+  name: 'int2bbool';
+  args: [
+    LiteralValue<number>
+  ];
+};
+
+export interface Fint2ddouble extends FunctionCall<number> {
+  name: 'int2ddouble';
+  args: [
+    LiteralValue<number>
+  ];
+};
+
+export interface Fintersection extends FunctionCall<string> {
+  name: 'intersection';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Fintersects extends FunctionCall<boolean> {
+  name: 'intersects';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Fintersects3D extends FunctionCall<number> {
+  name: 'intersects3D';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface FisCached extends FunctionCall<boolean> {
+  name: 'isCached';
+  args: [
+    LiteralValue<string>
+  ];
+};
+
+export interface FisCoverage extends FunctionCall<boolean> {
+  name: 'isCoverage';
+};
+
+export interface FisInstanceOf extends FunctionCall<boolean> {
+  name: 'isInstanceOf';
+  args: [
+    LiteralValue<string>
+  ];
+};
+
+export interface FisLike extends FunctionCall<boolean> {
+  name: 'isLike';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface FisNull extends FunctionCall<boolean> {
+  name: 'isNull';
+  args: [
+    LiteralValue<string>
+  ];
+};
+
+export interface FisWithinDistance extends FunctionCall<boolean> {
+  name: 'isWithinDistance';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<number>
+  ];
+};
+
+export interface FisWithinDistance3D extends FunctionCall<number> {
+  name: 'isWithinDistance3D';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<number>
+  ];
+};
+
+export interface FjsonPointer extends FunctionCall<string> {
+  name: 'jsonPointer';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Flapply extends FunctionCall<string> {
+  name: 'lapply';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Flength extends FunctionCall<number> {
+  name: 'length';
+  args: [
+    LiteralValue<string>
+  ];
+};
+
+export interface FlessEqualThan extends FunctionCall<boolean> {
+  name: 'lessEqualThan';
+  args: [
+    LiteralValue<number>,
+    LiteralValue<number>
+  ];
+};
+
+export interface FlessThan extends FunctionCall<boolean> {
+  name: 'lessThan';
+  args: [
+    LiteralValue<number>,
+    LiteralValue<number>
+  ];
+};
+
+export interface Flighten extends FunctionCall<string> {
+  name: 'lighten';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<number>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Flist extends FunctionCall<string> {
+  name: 'list';
+  args: [
+    LiteralValue<string>
+  ];
+};
+
+export interface FlistMultiply extends FunctionCall<string> {
+  name: 'listMultiply';
+  args: [
+    LiteralValue<number>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Flitem extends FunctionCall<string> {
+  name: 'litem';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<number>
+  ];
+};
+
+export interface Fliterate extends FunctionCall<string> {
+  name: 'literate';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<number>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Flog extends FunctionCall<number> {
+  name: 'log';
+  args: [
+    LiteralValue<number>
+  ];
+};
+
+export interface FmapGet extends FunctionCall<string> {
+  name: 'mapGet';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Fmax extends FunctionCall<number> {
+  name: 'max';
+  args: [
+    LiteralValue<number>,
+    LiteralValue<number>
+  ];
+};
+
+export interface Fmax_2 extends FunctionCall<number> {
+  name: 'max_2';
+  args: [
+    LiteralValue<number>,
+    LiteralValue<number>
+  ];
+};
+
+export interface Fmax_3 extends FunctionCall<number> {
+  name: 'max_3';
+  args: [
+    LiteralValue<number>,
+    LiteralValue<number>
+  ];
+};
+
+export interface Fmax_4 extends FunctionCall<number> {
+  name: 'max_4';
+  args: [
+    LiteralValue<number>,
+    LiteralValue<number>
+  ];
+};
+
+export interface Fmin extends FunctionCall<number> {
+  name: 'min';
+  args: [
+    LiteralValue<number>,
+    LiteralValue<number>
+  ];
+};
+
+export interface Fmin_2 extends FunctionCall<number> {
+  name: 'min_2';
+  args: [
+    LiteralValue<number>,
+    LiteralValue<number>
+  ];
+};
+
+export interface Fmin_3 extends FunctionCall<number> {
+  name: 'min_3';
+  args: [
+    LiteralValue<number>,
+    LiteralValue<number>
+  ];
+};
+
+export interface Fmin_4 extends FunctionCall<number> {
+  name: 'min_4';
+  args: [
+    LiteralValue<number>,
+    LiteralValue<number>
+  ];
+};
+
+export interface Fmix extends FunctionCall<string> {
+  name: 'mix';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<number>
+  ];
+};
+
+export interface Fmodulo extends FunctionCall<number> {
+  name: 'modulo';
+  args: [
+    LiteralValue<number>,
+    LiteralValue<number>
+  ];
+};
+
+export interface Fnot extends FunctionCall<boolean> {
+  name: 'not';
+  args: [
+    LiteralValue<boolean>
+  ];
+};
+
+export interface FnotEqualTo extends FunctionCall<boolean> {
+  name: 'notEqualTo';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface FnumberFormat extends FunctionCall<string> {
+  name: 'numberFormat';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<number>,
+    LiteralValue<string>
+  ];
+};
+
+export interface FnumberFormat2 extends FunctionCall<string> {
+  name: 'numberFormat2';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<number>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Foverlaps extends FunctionCall<string> {
+  name: 'overlaps';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Fparameter extends FunctionCall<string> {
+  name: 'parameter';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface FparseBoolean extends FunctionCall<boolean> {
+  name: 'parseBoolean';
+  args: [
+    LiteralValue<string>
+  ];
+};
+
+export interface FparseDouble extends FunctionCall<number> {
+  name: 'parseDouble';
+  args: [
+    LiteralValue<string>
+  ];
+};
+
+export interface FparseInt extends FunctionCall<number> {
+  name: 'parseInt';
+  args: [
+    LiteralValue<string>
+  ];
+};
+
+export interface FparseLong extends FunctionCall<number> {
+  name: 'parseLong';
+  args: [
+    LiteralValue<string>
+  ];
+};
+
+export interface Fpi extends FunctionCall<number> {
+  name: 'pi';
+};
+
+export interface Fpow extends FunctionCall<number> {
+  name: 'pow';
+  args: [
+    LiteralValue<number>,
+    LiteralValue<number>
+  ];
+};
+
+export interface Fproperty extends FunctionCall<string> {
+  name: 'property';
+  args: [
+    LiteralValue<string>
+  ];
+};
+
+export interface Frandom extends FunctionCall<number> {
+  name: 'random';
+};
+
+export interface Frelate extends FunctionCall<string> {
+  name: 'relate';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface FrescaleToPixels extends FunctionCall<string> {
+  name: 'rescaleToPixels';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<number>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Frint extends FunctionCall<number> {
+  name: 'rint';
+  args: [
+    LiteralValue<number>
+  ];
+};
+
+export interface Fround extends FunctionCall<number> {
+  name: 'round';
+  args: [
+    LiteralValue<number>
+  ];
+};
+
+export interface Fround_2 extends FunctionCall<number> {
+  name: 'round_2';
+  args: [
+    LiteralValue<number>
+  ];
+};
+
+export interface FroundDouble extends FunctionCall<number> {
+  name: 'roundDouble';
+  args: [
+    LiteralValue<number>
+  ];
+};
+
+export interface Fsaturate extends FunctionCall<string> {
+  name: 'saturate';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<number>,
+    LiteralValue<string>
+  ];
+};
+
+export interface Fshade extends FunctionCall<string> {
+  name: 'shade';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<number>
+  ];
+};
+
+export interface Fsin extends FunctionCall<number> {
+  name: 'sin';
+  args: [
+    LiteralValue<number>
+  ];
+};
+
+export interface Fsize extends FunctionCall<number> {
+  name: 'size';
+  args: [
+    LiteralValue<string>
+  ];
+};
+
+export interface Fspin extends FunctionCall<string> {
+  name: 'spin';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<number>
+  ];
+};
+
+export interface Fsqrt extends FunctionCall<number> {
+  name: 'sqrt';
+  args: [
+    LiteralValue<number>
+  ];
+};
+
+export interface FstartAngle extends FunctionCall<number> {
+  name: 'startAngle';
+  args: [
+    LiteralValue<string>
+  ];
+};
+
+export interface FstartPoint extends FunctionCall<string> {
+  name: 'startPoint';
+  args: [
+    LiteralValue<string>
+  ];
+};
+
+export interface FstrAbbreviate extends FunctionCall<string> {
+  name: 'strAbbreviate';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<number>,
+    LiteralValue<number>,
+    LiteralValue<string>
+  ];
+};
+
+export interface FstrCapitalize extends FunctionCall<string> {
+  name: 'strCapitalize';
+  args: [
+    LiteralValue<string>
+  ];
+};
+
+export interface FstrConcat extends FunctionCall<string> {
+  name: 'strConcat';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface FstrDefaultIfBlank extends FunctionCall<string> {
+  name: 'strDefaultIfBlank';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface FstrEndsWith extends FunctionCall<boolean> {
+  name: 'strEndsWith';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface FstrEqualsIgnoreCase extends FunctionCall<boolean> {
+  name: 'strEqualsIgnoreCase';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface FstrIndexOf extends FunctionCall<number> {
+  name: 'strIndexOf';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface FstringTemplate extends FunctionCall<string> {
+  name: 'stringTemplate';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface FstrLastIndexOf extends FunctionCall<number> {
+  name: 'strLastIndexOf';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface FstrLength extends FunctionCall<number> {
+  name: 'strLength';
+  args: [
+    LiteralValue<string>
+  ];
+};
+
+export interface FstrMatches extends FunctionCall<boolean> {
+  name: 'strMatches';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface FstrPosition extends FunctionCall<string> {
+  name: 'strPosition';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface FstrReplace extends FunctionCall<string> {
+  name: 'strReplace';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<boolean>
+  ];
+};
+
+export interface FstrStartsWith extends FunctionCall<boolean> {
+  name: 'strStartsWith';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface FstrStripAccents extends FunctionCall<string> {
+  name: 'strStripAccents';
+  args: [
+    LiteralValue<string>
+  ];
+};
+
+export interface FstrSubstring extends FunctionCall<string> {
+  name: 'strSubstring';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<number>,
+    LiteralValue<number>
+  ];
+};
+
+export interface FstrSubstringStart extends FunctionCall<string> {
+  name: 'strSubstringStart';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<number>
+  ];
+};
+
+export interface FstrToLowerCase extends FunctionCall<string> {
+  name: 'strToLowerCase';
+  args: [
+    LiteralValue<string>
+  ];
+};
+
+export interface FstrToUpperCase extends FunctionCall<string> {
+  name: 'strToUpperCase';
+  args: [
+    LiteralValue<string>
+  ];
+};
+
+export interface FstrTrim extends FunctionCall<string> {
+  name: 'strTrim';
+  args: [
+    LiteralValue<string>
+  ];
+};
+
+export interface FstrTrim2 extends FunctionCall<string> {
+  name: 'strTrim2';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<string>,
+    LiteralValue<string>
+  ];
+};
+
+export interface FstrURLEncode extends FunctionCall<string> {
+  name: 'strURLEncode';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<boolean>
+  ];
+};
+
+export interface Ftan extends FunctionCall<number> {
+  name: 'tan';
+  args: [
+    LiteralValue<number>
+  ];
+};
+
+export interface Ftint extends FunctionCall<string> {
+  name: 'tint';
+  args: [
+    LiteralValue<string>,
+    LiteralValue<number>
+  ];
+};
+
+export interface FtoDegrees extends FunctionCall<number> {
+  name: 'toDegrees';
+  args: [
+    LiteralValue<number>
+  ];
+};
+
+export interface FtoRadians extends FunctionCall<number> {
+  name: 'toRadians';
+  args: [
+    LiteralValue<number>
+  ];
+};
+
+export type GeoStylerFunction = Fabs |
+Fabs_2 |
+Fabs_3 |
+Fabs_4 |
+Facos |
+Farray |
+Fasin |
+Fatan |
+Fatan2 |
+FattributeCount |
+Fbetween |
+FboundedBy |
+Fceil |
+Fclassify |
+Fcontains |
+Fcontrast |
+Fconvert |
+Fcos |
+Fcrosses |
+Fdarken |
+Fdesaturate |
+Fdifference |
+Fdisjoint |
+Fdisjoint3D |
+Fdistance |
+Fdistance3D |
+Fdouble2bool |
+FendAngle |
+FendPoint |
+Fenv |
+FequalsExact |
+FequalsExactTolerance |
+FequalTo |
+Fexp |
+Ffloor |
+Fgrayscale |
+FgreaterEqualThan |
+FgreaterThan |
+Fhsl |
+Fid |
+Fif_then_else |
+Fin |
+Fin10 |
+Fin2 |
+Fin3 |
+Fin4 |
+Fin5 |
+Fin6 |
+Fin7 |
+Fin8 |
+Fin9 |
+FinArray |
+Fint2bbool |
+Fint2ddouble |
+Fintersection |
+Fintersects |
+Fintersects3D |
+FisCached |
+FisCoverage |
+FisInstanceOf |
+FisLike |
+FisNull |
+FisWithinDistance |
+FisWithinDistance3D |
+FjsonPointer |
+Flapply |
+Flength |
+FlessEqualThan |
+FlessThan |
+Flighten |
+Flist |
+FlistMultiply |
+Flitem |
+Fliterate |
+Flog |
+FmapGet |
+Fmax |
+Fmax_2 |
+Fmax_3 |
+Fmax_4 |
+Fmin |
+Fmin_2 |
+Fmin_3 |
+Fmin_4 |
+Fmix |
+Fmodulo |
+Fnot |
+FnotEqualTo |
+FnumberFormat |
+FnumberFormat2 |
+Foverlaps |
+Fparameter |
+FparseBoolean |
+FparseDouble |
+FparseInt |
+FparseLong |
+Fpi |
+Fpow |
+Fproperty |
+Frandom |
+Frelate |
+FrescaleToPixels |
+Frint |
+Fround |
+Fround_2 |
+FroundDouble |
+Fsaturate |
+Fshade |
+Fsin |
+Fsize |
+Fspin |
+Fsqrt |
+FstartAngle |
+FstartPoint |
+FstrAbbreviate |
+FstrCapitalize |
+FstrConcat |
+FstrDefaultIfBlank |
+FstrEndsWith |
+FstrEqualsIgnoreCase |
+FstrIndexOf |
+FstringTemplate |
+FstrLastIndexOf |
+FstrLength |
+FstrMatches |
+FstrPosition |
+FstrReplace |
+FstrStartsWith |
+FstrStripAccents |
+FstrSubstring |
+FstrSubstringStart |
+FstrToLowerCase |
+FstrToUpperCase |
+FstrTrim |
+FstrTrim2 |
+FstrURLEncode |
+Ftan |
+Ftint |
+FtoDegrees |
+FtoRadians;

--- a/functions.ts
+++ b/functions.ts
@@ -353,10 +353,7 @@ export interface FstrCapitalize extends FunctionCall<string> {
  */
 export interface FstrConcat extends FunctionCall<string> {
   name: 'strConcat';
-  args: [
-    Expression<string>,
-    Expression<string>
-  ];
+  args: Expression<string>[];
 };
 
 /**

--- a/index.ts
+++ b/index.ts
@@ -1,2 +1,3 @@
 export * from './style';
+export * from './functions';
 export * from './typeguards';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geostyler-style",
-  "version": "6.0.0",
+  "version": "7.0.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "geostyler-style",
-      "version": "6.0.0",
+      "version": "7.0.0-beta.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@types/lodash": "^4.14.168",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@typescript-eslint/parser": "^5.22.0",
     "core-js": "^3.22.8",
     "eslint": "^8.14.0",
-    "eslint-plugin-react-hooks": "^4.5.0",
     "np": "^7.6.1",
     "typedoc": "^0.23.10",
     "typescript": "^4.6.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geostyler-style",
-  "version": "6.0.0",
+  "version": "7.0.0-beta.0",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/schema.json
+++ b/schema.json
@@ -10,7 +10,51 @@
                     "description": "A ContrastEnhancement defines how the contrast of image data should be enhanced."
                 },
                 "sourceChannelName": {
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Expressions can be a literal value, a property name or a function call."
                 }
             },
             "type": "object"
@@ -25,7 +69,39 @@
                     "type": "array"
                 },
                 "extended": {
-                    "type": "boolean"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEndsWith"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEqualsIgnoreCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrMatches"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStartsWith"
+                        },
+                        {
+                            "type": "boolean"
+                        }
+                    ],
+                    "description": "Expressions can be a literal value, a property name or a function call."
                 },
                 "type": {
                     "$ref": "http://geostyler/geostyler-style.json#/definitions/ColorMapType"
@@ -37,16 +113,276 @@
             "description": "A single entry for the ColorMap.",
             "properties": {
                 "color": {
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Expressions can be a literal value, a property name or a function call."
                 },
                 "label": {
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Expressions can be a literal value, a property name or a function call."
                 },
                 "opacity": {
-                    "type": "number"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ],
+                    "description": "Expressions can be a literal value, a property name or a function call."
                 },
                 "quantity": {
-                    "type": "number"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ],
+                    "description": "Expressions can be a literal value, a property name or a function call."
                 }
             },
             "type": "object"
@@ -89,7 +425,1408 @@
                     "type": "string"
                 },
                 "gammaValue": {
-                    "type": "number"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ],
+                    "description": "Expressions can be a literal value, a property name or a function call."
+                }
+            },
+            "type": "object"
+        },
+        "Fabs": {
+            "description": "The absolute value of the specified number value",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 1,
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "abs"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Facos": {
+            "description": "Returns the arc cosine of an angle in radians, in the range of 0.0 through PI",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 1,
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "acos"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Fasin": {
+            "description": "Returns the arc sine of an angle in radians, in the range of -PI / 2 through PI / 2",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 1,
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "asin"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Fatan": {
+            "description": "Returns the arc tangent of an angle in radians, in the range of -PI/2 through PI/2",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 1,
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "atan"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Fatan2": {
+            "description": "Converts a rectangular coordinate (x, y) to polar (r, theta) and returns theta.",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 2,
+                    "minItems": 2,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "atan2"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Fbetween": {
+            "description": "Returns true if arg1 <= arg0 <= arg2",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 3,
+                    "minItems": 3,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "between"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Fceil": {
+            "description": "Returns the smallest (closest to negative infinity) number value that is greater than or equal to\nx and is equal to a mathematical integer.",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 1,
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "ceil"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Fcos": {
+            "description": "Returns the cosine of an angle expressed in radians",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 1,
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "cos"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Fdouble2bool": {
+            "description": "Returns true if x is zero, false otherwise",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 1,
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "double2bool"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Fexp": {
+            "description": "Returns Euler’s number e raised to the power of x",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 1,
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "exp"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Ffloor": {
+            "description": "Returns the largest (closest to positive infinity) value that is less than or equal to x and is\nequal to a mathematical integer",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 1,
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "floor"
+                    ],
+                    "type": "string"
                 }
             },
             "type": "object"
@@ -100,22 +1837,31 @@
                 "antialias": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEndsWith"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEqualsIgnoreCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrMatches"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStartsWith"
                         },
                         {
                             "type": "boolean"
@@ -126,22 +1872,43 @@
                 "color": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
                         },
                         {
                             "type": "string"
@@ -152,22 +1919,85 @@
                 "fillOpacity": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -199,22 +2029,85 @@
                 "opacity": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -225,22 +2118,43 @@
                 "outlineColor": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
                         },
                         {
                             "type": "string"
@@ -251,29 +2165,177 @@
                 "outlineDasharray": {
                     "description": "Encodes a dash pattern as an array of numbers. Odd-indexed numbers (first,\nthird, etc) determine the length in pixels to draw the line, and even-indexed\nnumbers (second, fourth, etc) determine the length in pixels to blank out\nthe line. Default is an unbroken line.",
                     "items": {
-                        "type": "number"
+                        "anyOf": [
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                            },
+                            {
+                                "type": "number"
+                            }
+                        ]
                     },
                     "type": "array"
                 },
                 "outlineOpacity": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -284,22 +2346,85 @@
                 "outlineWidth": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -318,22 +2443,31 @@
                 "visibility": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEndsWith"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEqualsIgnoreCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrMatches"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStartsWith"
                         },
                         {
                             "type": "boolean"
@@ -347,26 +2481,6 @@
         "Filter": {
             "anyOf": [
                 {
-                    "description": "A FunctionFilter that expects an Expression as second and\nthird argument. The function checks, if the evaluation of\nthe second argument matches the evaluation of the third one.\nAn actual parser implementation has to return a value for\nthis function expression.",
-                    "items": [
-                        {
-                            "enum": [
-                                "FN_strMatches"
-                            ],
-                            "type": "string"
-                        },
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/RegExp"
-                        }
-                    ],
-                    "maxItems": 3,
-                    "minItems": 3,
-                    "type": "array"
-                },
-                {
                     "description": "A Filter that checks if a property is in a range of two values (inclusive).",
                     "items": [
                         {
@@ -378,42 +2492,43 @@
                         {
                             "anyOf": [
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
                                 },
                                 {
-                                    "description": "A FunctionFilter that expects an Expression as second and\nthird argument. The function checks, if the evaluation of\nthe second argument matches the evaluation of the third one.\nAn actual parser implementation has to return a value for\nthis function expression.",
-                                    "items": [
-                                        {
-                                            "enum": [
-                                                "FN_strMatches"
-                                            ],
-                                            "type": "string"
-                                        },
-                                        {
-                                            "type": "string"
-                                        },
-                                        {
-                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/RegExp"
-                                        }
-                                    ],
-                                    "maxItems": 3,
-                                    "minItems": 3,
-                                    "type": "array"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
                                 },
                                 {
                                     "type": "string"
@@ -423,22 +2538,85 @@
                         {
                             "anyOf": [
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                                 },
                                 {
                                     "type": "number"
@@ -448,22 +2626,85 @@
                         {
                             "anyOf": [
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                                 },
                                 {
                                     "type": "number"
@@ -494,27 +2735,151 @@
                         {
                             "anyOf": [
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEndsWith"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEqualsIgnoreCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrMatches"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStartsWith"
                                 },
                                 {
                                     "type": [
                                         "string",
-                                        "number"
+                                        "number",
+                                        "boolean"
                                     ]
                                 }
                             ]
@@ -522,27 +2887,151 @@
                         {
                             "anyOf": [
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEndsWith"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEqualsIgnoreCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrMatches"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStartsWith"
                                 },
                                 {
                                     "type": [
                                         "string",
-                                        "number"
+                                        "number",
+                                        "boolean"
                                     ]
                                 }
                             ]
@@ -553,7 +3042,8 @@
                     "type": "array"
                 },
                 {
-                    "$ref": "http://geostyler/geostyler-style.json#/definitions/CombinationFilter"
+                    "$ref": "http://geostyler/geostyler-style.json#/definitions/CombinationFilter",
+                    "description": "A CombinationFilter combines N Filters with a logical OR / AND operator."
                 },
                 {
                     "description": "A NegationFilter negates a given Filter.",
@@ -574,41 +3064,4015 @@
                 }
             ]
         },
-        "FunctionCall": {
-            "description": "Expression that evaluates to the result of a function\ncall on a list of argument expressions.",
+        "Fin": {
+            "description": "Returns true if arguments[0] is equal to one of the arguments[1], …, arguments[n] values. Use the\nfunction name matching the number of arguments specified.",
             "properties": {
                 "args": {
                     "items": {
                         "anyOf": [
                             {
-                                "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                             },
                             {
-                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
                             },
                             {
-                                "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
                             },
                             {
-                                "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
                             },
                             {
-                                "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
                             },
                             {
-                                "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                            },
+                            {
+                                "type": "string"
                             }
-                        ],
-                        "description": "Expressions can be a literal value, a property name or a function call."
+                        ]
                     },
                     "type": "array"
                 },
                 "name": {
-                    "type": "string"
-                },
-                "type": {
                     "enum": [
-                        "functioncall"
+                        "in"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Flog": {
+            "description": "Returns the natural logarithm (base e) of x",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 1,
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "log"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Fmax": {
+            "description": "Returns the maximum between argument[0], …, argument[n]",
+            "properties": {
+                "args": {
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                            },
+                            {
+                                "type": "number"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "max"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Fmin": {
+            "description": "Returns the minimum between argument[0], …, argument[n]",
+            "properties": {
+                "args": {
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                            },
+                            {
+                                "type": "number"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "min"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Fmodulo": {
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 2,
+                    "minItems": 2,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "modulo"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "FnumberFormat": {
+            "description": "Formats the number (argument[1]) according to the specified format (arguments[0]) using the default locale\nor the one provided (argument[2]) as an optional argument. The format syntax can be found\nin the Java DecimalFormat javadocs",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 3,
+                    "minItems": 3,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "numberFormat"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "FparseBoolean": {
+            "description": "Parses a string into a boolean. The empty string, f, 0.0 and 0 are considered false, everything\nelse is considered true.",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 1,
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "parseBoolean"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Fpi": {
+            "description": "Returns an approximation of pi, the ratio of the circumference of a circle to its diameter",
+            "properties": {
+                "name": {
+                    "enum": [
+                        "pi"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Fpow": {
+            "description": "Returns the value of base (argument[0]) raised to the power of exponent (arguments[1])",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 2,
+                    "minItems": 2,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "pow"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Fproperty": {
+            "description": "Returns the value of the property propertyName. Allows property names to be compute\nor specified by Variable substitution in SLD.",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 1,
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "property"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Frandom": {
+            "description": "Returns a Double value with a positive sign, greater than or equal to 0.0 and less than 1.0.",
+            "properties": {
+                "name": {
+                    "enum": [
+                        "random"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Frint": {
+            "description": "Returns the Double value that is closest in value to the argument and is equal to a mathematical\ninteger. If two double values that are mathematical integers are equally close, the result is the\ninteger value that is even.",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 1,
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "rint"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Fround": {
+            "description": "Returns the closest number to argument[0].",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 1,
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "round"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Fsin": {
+            "description": "Returns the sine of an angle expressed in radians",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 1,
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "sin"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Fsqrt": {
+            "description": "Returns the square root of argument[0]",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 1,
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "sqrt"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "FstrAbbreviate": {
+            "description": "Abbreviates the sentence (argument[0]) at first space beyond lower (argument[1])\nor at upper (argument[2]) if no space.Appends append (argument[3]) if string is abbreviated.",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 4,
+                    "minItems": 4,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "strAbbreviate"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "FstrCapitalize": {
+            "description": "Fully capitalizes the sentence. For example, “HoW aRe YOU?” will be turned into “How Are You?”",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 1,
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "strCapitalize"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "FstrConcat": {
+            "description": "Concatenates the two strings into one",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 2,
+                    "minItems": 2,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "strConcat"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "FstrDefaultIfBlank": {
+            "description": "Returns default (argument[1]) if str (argument[0]) is empty, blank or null",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 2,
+                    "minItems": 2,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "strDefaultIfBlank"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "FstrEndsWith": {
+            "description": "Returns true if string (argument[0]) ends with suffix (argument[1])",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 2,
+                    "minItems": 2,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "strEndsWith"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "FstrEqualsIgnoreCase": {
+            "description": "Returns true if the two strings are equal ignoring case considerations",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 2,
+                    "minItems": 2,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "strEqualsIgnoreCase"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "FstrIndexOf": {
+            "description": "Returns the index within this string (argument[0]) of the first occurrence of the specified\nsubstring (argument[1]), or -1 if not found",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 2,
+                    "minItems": 2,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "strIndexOf"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "FstrLastIndexOf": {
+            "description": "Returns the index within this string (arguments[0]) of the last occurrence of the specified\nsubstring (arguments[1]), or -1 if not found",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 2,
+                    "minItems": 2,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "strLastIndexOf"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "FstrLength": {
+            "description": "Returns the string length",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 1,
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "strLength"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "FstrMatches": {
+            "description": "Returns true if the string (arguments[0]) matches the specified regular expression (arguments[1]).\nFor the full syntax of the pattern specification see the Java Pattern class javadocs",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 2,
+                    "minItems": 2,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "strMatches"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "FstrReplace": {
+            "description": "Returns the string (argument[0]) with the pattern (argument[1]) replaced with the given\nreplacement (argument[2]) text. If the global argument (argument[3]) is true then all occurrences of the pattern\nwill be replaced, otherwise only the first. For the full syntax of the pattern specification see\nthe Java Pattern class javadocs",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEndsWith"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEqualsIgnoreCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrMatches"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStartsWith"
+                                },
+                                {
+                                    "type": "boolean"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 4,
+                    "minItems": 4,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "strReplace"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "FstrStartsWith": {
+            "description": "Returns true if string (argument[0]) starts with prefix (argument[1]).",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 2,
+                    "minItems": 2,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "strStartsWith"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "FstrStripAccents": {
+            "description": "Removes diacritics (~= accents) from a string. The case will not be altered.",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 1,
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "strStripAccents"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "FstrSubstring": {
+            "description": "Returns a new string that is a substring of this string (argument[0]). The substring begins\nat the specified begin (argument[1]) and extends to the character at index endIndex (argument[2]) - 1\n(indexes are zero-based).",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 3,
+                    "minItems": 3,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "strSubstring"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "FstrSubstringStart": {
+            "description": "Returns a new string that is a substring of this string (argument[0]). The substring begins\nat the specified begin (arguments[1]) and extends to the last character of the string",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 2,
+                    "minItems": 2,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "strSubstringStart"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "FstrToLowerCase": {
+            "description": "Returns the lower case version of the string",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 1,
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "strToLowerCase"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "FstrToUpperCase": {
+            "description": "Returns the upper case version of the string",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 1,
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "strToUpperCase"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "FstrTrim": {
+            "description": "Returns a copy of the string, with leading and trailing blank-space omitted",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 1,
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "strTrim"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Ftan": {
+            "description": "Returns the trigonometric tangent of angle expressed in radians",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 1,
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "tan"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "FtoDegrees": {
+            "description": "Converts an angle expressed in radians into degrees",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 1,
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "toDegrees"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "FtoRadians": {
+            "description": "Converts an angle expressed in radians into degrees",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 1,
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "toRadians"
                     ],
                     "type": "string"
                 }
@@ -630,22 +7094,31 @@
                 "allowOverlap": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEndsWith"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEqualsIgnoreCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrMatches"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStartsWith"
                         },
                         {
                             "type": "boolean"
@@ -671,22 +7144,31 @@
                 "avoidEdges": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEndsWith"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEqualsIgnoreCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrMatches"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStartsWith"
                         },
                         {
                             "type": "boolean"
@@ -697,22 +7179,43 @@
                 "color": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
                         },
                         {
                             "type": "string"
@@ -734,22 +7237,85 @@
                 "haloBlur": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -760,22 +7326,43 @@
                 "haloColor": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
                         },
                         {
                             "type": "string"
@@ -786,22 +7373,85 @@
                 "haloWidth": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -820,22 +7470,43 @@
                 "image": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
                         },
                         {
                             "type": "string"
@@ -846,22 +7517,31 @@
                 "keepUpright": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEndsWith"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEqualsIgnoreCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrMatches"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStartsWith"
                         },
                         {
                             "type": "boolean"
@@ -882,22 +7562,85 @@
                         {
                             "anyOf": [
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                                 },
                                 {
                                     "type": "number"
@@ -907,22 +7650,85 @@
                         {
                             "anyOf": [
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                                 },
                                 {
                                     "type": "number"
@@ -945,22 +7751,85 @@
                 "opacity": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -971,22 +7840,31 @@
                 "optional": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEndsWith"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEqualsIgnoreCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrMatches"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStartsWith"
                         },
                         {
                             "type": "boolean"
@@ -997,22 +7875,85 @@
                 "padding": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -1032,22 +7973,85 @@
                 "rotate": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -1067,22 +8071,85 @@
                 "size": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -1112,16 +8179,356 @@
                     "description": "Property relevant for mapbox-styles.\nCompare https://docs.mapbox.com/mapbox-gl-js/style-spec/#layout-symbol-icon-text-fit-padding",
                     "items": [
                         {
-                            "type": "number"
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
                         },
                         {
-                            "type": "number"
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
                         },
                         {
-                            "type": "number"
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
                         },
                         {
-                            "type": "number"
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
                         }
                     ],
                     "maxItems": 4,
@@ -1131,22 +8538,31 @@
                 "visibility": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEndsWith"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEqualsIgnoreCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrMatches"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStartsWith"
                         },
                         {
                             "type": "boolean"
@@ -1163,27 +8579,91 @@
                 "blur": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
                         }
-                    ]
+                    ],
+                    "description": "Expressions can be a literal value, a property name or a function call."
                 },
                 "cap": {
                     "description": "Determines how lines are rendered at their ends. Possible values are butt\n(sharp square edge), round (rounded edge), and square (slightly elongated\nsquare edge).",
@@ -1197,22 +8677,43 @@
                 "color": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
                         },
                         {
                             "type": "string"
@@ -1223,22 +8724,85 @@
                 "dashOffset": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -1249,29 +8813,177 @@
                 "dasharray": {
                     "description": "Encodes a dash pattern as an array of numbers. Odd-indexed numbers (first,\nthird, etc) determine the length in pixels to draw the line, and even-indexed\nnumbers (second, fourth, etc) determine the length in pixels to blank out\nthe line. Default is an unbroken line.",
                     "items": {
-                        "type": "number"
+                        "anyOf": [
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                            },
+                            {
+                                "type": "number"
+                            }
+                        ]
                     },
                     "type": "array"
                 },
                 "gapWidth": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -1339,22 +9051,85 @@
                 "miterLimit": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -1365,22 +9140,85 @@
                 "opacity": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -1391,22 +9229,85 @@
                 "perpendicularOffset": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -1417,22 +9318,85 @@
                 "roundLimit": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -1443,22 +9407,85 @@
                 "spacing": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -1478,22 +9505,31 @@
                 "visibility": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEndsWith"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEqualsIgnoreCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrMatches"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStartsWith"
                         },
                         {
                             "type": "boolean"
@@ -1504,22 +9540,85 @@
                 "width": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -1538,88 +9637,37 @@
             },
             "type": "object"
         },
-        "LiteralValue<boolean>": {
-            "description": "Expression that evaluates to the given value.",
-            "properties": {
-                "type": {
-                    "enum": [
-                        "literal"
-                    ],
-                    "type": "string"
-                },
-                "value": {
-                    "type": "boolean"
-                }
-            },
-            "type": "object"
-        },
-        "LiteralValue<null>": {
-            "description": "Expression that evaluates to the given value.",
-            "properties": {
-                "type": {
-                    "enum": [
-                        "literal"
-                    ],
-                    "type": "string"
-                },
-                "value": {
-                    "type": "null"
-                }
-            },
-            "type": "object"
-        },
-        "LiteralValue<number>": {
-            "description": "Expression that evaluates to the given value.",
-            "properties": {
-                "type": {
-                    "enum": [
-                        "literal"
-                    ],
-                    "type": "string"
-                },
-                "value": {
-                    "type": "number"
-                }
-            },
-            "type": "object"
-        },
-        "LiteralValue<string>": {
-            "description": "Expression that evaluates to the given value.",
-            "properties": {
-                "type": {
-                    "enum": [
-                        "literal"
-                    ],
-                    "type": "string"
-                },
-                "value": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
         "MarkSymbolizer": {
             "description": "MarkSymbolizer describes the style representation of POINT data, if styled as\nwith a regular geometry.",
             "properties": {
                 "avoidEdges": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEndsWith"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEqualsIgnoreCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrMatches"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStartsWith"
                         },
                         {
                             "type": "boolean"
@@ -1630,22 +9678,85 @@
                 "blur": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -1656,22 +9767,43 @@
                 "color": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
                         },
                         {
                             "type": "string"
@@ -1682,22 +9814,85 @@
                 "fillOpacity": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -1718,22 +9913,85 @@
                         {
                             "anyOf": [
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                                 },
                                 {
                                     "type": "number"
@@ -1743,22 +10001,85 @@
                         {
                             "anyOf": [
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                                 },
                                 {
                                     "type": "number"
@@ -1781,22 +10102,85 @@
                 "opacity": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -1823,22 +10207,85 @@
                 "radius": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -1857,22 +10304,85 @@
                 "rotate": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -1883,22 +10393,43 @@
                 "strokeColor": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
                         },
                         {
                             "type": "string"
@@ -1909,22 +10440,85 @@
                 "strokeOpacity": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -1935,22 +10529,85 @@
                 "strokeWidth": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -1969,22 +10626,31 @@
                 "visibility": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEndsWith"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEqualsIgnoreCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrMatches"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStartsWith"
                         },
                         {
                             "type": "boolean"
@@ -2043,21 +10709,6 @@
             "minItems": 2,
             "type": "array"
         },
-        "PropertyName": {
-            "description": "Expression that evaluates to the value of the given property.",
-            "properties": {
-                "name": {
-                    "type": "string"
-                },
-                "type": {
-                    "enum": [
-                        "property"
-                    ],
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
         "RGBChannel": {
             "description": "A RGBChannel defines how dataset bands are mapped to image color channels.",
             "properties": {
@@ -2077,10 +10728,182 @@
             "description": "A RasterSymbolizer defines the style representation of RASTER data.",
             "properties": {
                 "brightnessMax": {
-                    "type": "number"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ],
+                    "description": "Expressions can be a literal value, a property name or a function call."
                 },
                 "brightnessMin": {
-                    "type": "number"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ],
+                    "description": "Expressions can be a literal value, a property name or a function call."
                 },
                 "channelSelection": {
                     "anyOf": [
@@ -2097,17 +10920,275 @@
                     "description": "A ColorMap defines the color values for the pixels of a raster image."
                 },
                 "contrast": {
-                    "type": "number"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ],
+                    "description": "Expressions can be a literal value, a property name or a function call."
                 },
                 "contrastEnhancement": {
                     "$ref": "http://geostyler/geostyler-style.json#/definitions/ContrastEnhancement",
                     "description": "A ContrastEnhancement defines how the contrast of image data should be enhanced."
                 },
                 "fadeDuration": {
-                    "type": "number"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ],
+                    "description": "Expressions can be a literal value, a property name or a function call."
                 },
                 "hueRotate": {
-                    "type": "number"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ],
+                    "description": "Expressions can be a literal value, a property name or a function call."
                 },
                 "kind": {
                     "enum": [
@@ -2116,7 +11197,93 @@
                     "type": "string"
                 },
                 "opacity": {
-                    "type": "number"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ],
+                    "description": "Expressions can be a literal value, a property name or a function call."
                 },
                 "resampling": {
                     "enum": [
@@ -2126,42 +11293,128 @@
                     "type": "string"
                 },
                 "saturation": {
-                    "type": "number"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ],
+                    "description": "Expressions can be a literal value, a property name or a function call."
                 },
                 "visibility": {
-                    "type": "boolean"
-                }
-            },
-            "type": "object"
-        },
-        "RegExp": {
-            "properties": {
-                "dotAll": {
-                    "type": "boolean"
-                },
-                "flags": {
-                    "type": "string"
-                },
-                "global": {
-                    "type": "boolean"
-                },
-                "ignoreCase": {
-                    "type": "boolean"
-                },
-                "lastIndex": {
-                    "type": "number"
-                },
-                "multiline": {
-                    "type": "boolean"
-                },
-                "source": {
-                    "type": "string"
-                },
-                "sticky": {
-                    "type": "boolean"
-                },
-                "unicode": {
-                    "type": "boolean"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEndsWith"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEqualsIgnoreCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrMatches"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStartsWith"
+                        },
+                        {
+                            "type": "boolean"
+                        }
+                    ],
+                    "description": "Expressions can be a literal value, a property name or a function call."
                 }
             },
             "type": "object"
@@ -2171,26 +11424,6 @@
             "properties": {
                 "filter": {
                     "anyOf": [
-                        {
-                            "description": "A FunctionFilter that expects an Expression as second and\nthird argument. The function checks, if the evaluation of\nthe second argument matches the evaluation of the third one.\nAn actual parser implementation has to return a value for\nthis function expression.",
-                            "items": [
-                                {
-                                    "enum": [
-                                        "FN_strMatches"
-                                    ],
-                                    "type": "string"
-                                },
-                                {
-                                    "type": "string"
-                                },
-                                {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/RegExp"
-                                }
-                            ],
-                            "maxItems": 3,
-                            "minItems": 3,
-                            "type": "array"
-                        },
                         {
                             "description": "A Filter that checks if a property is in a range of two values (inclusive).",
                             "items": [
@@ -2203,42 +11436,43 @@
                                 {
                                     "anyOf": [
                                         {
-                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                         },
                                         {
-                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
                                         },
                                         {
-                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
                                         },
                                         {
-                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
                                         },
                                         {
-                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
                                         },
                                         {
-                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
                                         },
                                         {
-                                            "description": "A FunctionFilter that expects an Expression as second and\nthird argument. The function checks, if the evaluation of\nthe second argument matches the evaluation of the third one.\nAn actual parser implementation has to return a value for\nthis function expression.",
-                                            "items": [
-                                                {
-                                                    "enum": [
-                                                        "FN_strMatches"
-                                                    ],
-                                                    "type": "string"
-                                                },
-                                                {
-                                                    "type": "string"
-                                                },
-                                                {
-                                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/RegExp"
-                                                }
-                                            ],
-                                            "maxItems": 3,
-                                            "minItems": 3,
-                                            "type": "array"
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
                                         },
                                         {
                                             "type": "string"
@@ -2248,22 +11482,85 @@
                                 {
                                     "anyOf": [
                                         {
-                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                         },
                                         {
-                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                                         },
                                         {
-                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                                         },
                                         {
-                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                                         },
                                         {
-                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                                         },
                                         {
-                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                                         },
                                         {
                                             "type": "number"
@@ -2273,22 +11570,85 @@
                                 {
                                     "anyOf": [
                                         {
-                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                         },
                                         {
-                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                                         },
                                         {
-                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                                         },
                                         {
-                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                                         },
                                         {
-                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                                         },
                                         {
-                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                                         },
                                         {
                                             "type": "number"
@@ -2319,27 +11679,151 @@
                                 {
                                     "anyOf": [
                                         {
-                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                         },
                                         {
-                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                                         },
                                         {
-                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                                         },
                                         {
-                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                                         },
                                         {
-                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                                         },
                                         {
-                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEndsWith"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEqualsIgnoreCase"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrMatches"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStartsWith"
                                         },
                                         {
                                             "type": [
                                                 "string",
-                                                "number"
+                                                "number",
+                                                "boolean"
                                             ]
                                         }
                                     ]
@@ -2347,27 +11831,151 @@
                                 {
                                     "anyOf": [
                                         {
-                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                         },
                                         {
-                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                                         },
                                         {
-                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                                         },
                                         {
-                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                                         },
                                         {
-                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                                         },
                                         {
-                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEndsWith"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEqualsIgnoreCase"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrMatches"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStartsWith"
                                         },
                                         {
                                             "type": [
                                                 "string",
-                                                "number"
+                                                "number",
+                                                "boolean"
                                             ]
                                         }
                                     ]
@@ -2427,12 +12035,182 @@
             "description": "The ScaleDenominator defines a range of scales.",
             "properties": {
                 "max": {
-                    "description": "Maximum value of the ScaleDenominator. The value is exclusive.",
-                    "type": "number"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ],
+                    "description": "Maximum value of the ScaleDenominator. The value is exclusive."
                 },
                 "min": {
-                    "description": "Minimum value of the ScaleDenominator. The value is inclusive.",
-                    "type": "number"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ],
+                    "description": "Minimum value of the ScaleDenominator. The value is inclusive."
                 }
             },
             "type": "object"
@@ -2443,22 +12221,31 @@
                 "allowOverlap": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEndsWith"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEqualsIgnoreCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrMatches"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStartsWith"
                         },
                         {
                             "type": "boolean"
@@ -2484,22 +12271,31 @@
                 "avoidEdges": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEndsWith"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEqualsIgnoreCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrMatches"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStartsWith"
                         },
                         {
                             "type": "boolean"
@@ -2510,22 +12306,43 @@
                 "color": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
                         },
                         {
                             "type": "string"
@@ -2536,7 +12353,50 @@
                 "font": {
                     "description": "An Array of fonts. Comparable to https://www.w3schools.com/cssref/pr_font_font-family.asp",
                     "items": {
-                        "type": "string"
+                        "anyOf": [
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ]
                     },
                     "type": "array"
                 },
@@ -2560,22 +12420,85 @@
                 "haloBlur": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -2586,22 +12509,43 @@
                 "haloColor": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
                         },
                         {
                             "type": "string"
@@ -2612,22 +12556,85 @@
                 "haloWidth": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -2655,22 +12662,31 @@
                 "keepUpright": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEndsWith"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEqualsIgnoreCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrMatches"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStartsWith"
                         },
                         {
                             "type": "boolean"
@@ -2686,28 +12702,134 @@
                     "type": "string"
                 },
                 "label": {
-                    "description": "Template string where {{PROPERTYNAME}} can be used to be replaced by values\nfrom the dataset.\ne.g.: \"Name {{country_name}}\"",
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Template string where {{PROPERTYNAME}} can be used to be replaced by values\nfrom the dataset.\ne.g.: \"Name {{country_name}}\""
                 },
                 "letterSpacing": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -2727,22 +12849,85 @@
                 "lineHeight": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -2762,22 +12947,85 @@
                 "maxAngle": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -2788,22 +13036,85 @@
                 "maxWidth": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -2817,22 +13128,85 @@
                         {
                             "anyOf": [
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                                 },
                                 {
                                     "type": "number"
@@ -2842,22 +13216,85 @@
                         {
                             "anyOf": [
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                                 },
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                                 },
                                 {
                                     "type": "number"
@@ -2880,22 +13317,85 @@
                 "opacity": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -2906,22 +13406,31 @@
                 "optional": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEndsWith"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEqualsIgnoreCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrMatches"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStartsWith"
                         },
                         {
                             "type": "boolean"
@@ -2932,22 +13441,85 @@
                 "padding": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -2967,22 +13539,85 @@
                 "rotate": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -3002,22 +13637,85 @@
                 "size": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
                         },
                         {
                             "type": "number"
@@ -3037,22 +13735,31 @@
                 "visibility": {
                     "anyOf": [
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/PropertyName"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FunctionCall"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<string>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<number>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<boolean>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
                         },
                         {
-                            "$ref": "http://geostyler/geostyler-style.json#/definitions/LiteralValue<null>"
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEndsWith"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEqualsIgnoreCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrMatches"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStartsWith"
                         },
                         {
                             "type": "boolean"

--- a/style.ts
+++ b/style.ts
@@ -20,41 +20,21 @@ export interface ScaleDenominator {
 }
 
 /**
- * A base interface for expressions.
- */
-export interface AbstractExpression {
-  type: string;
-};
-
-
-/**
- * Expression that evaluates to the value of the given property.
- */
-export interface PropertyName extends AbstractExpression {
-  type: 'property';
-  name: Expression<string>;
-};
-
-/**
  * Expression that evaluates to the result of a function
  * call on a list of argument expressions.
  */
-export interface FunctionCall<T> extends AbstractExpression {
-  type: T extends string ? 'stringfunction' :
-    T extends number ? 'numberfunction' :
-    T extends boolean ? 'booleanfunction' :
-    'voidfunction';
+export interface FunctionCall<T> {
   name: T extends string ? GeoStylerStringFunction['name'] :
     T extends number ? GeoStylerNumberFunction['name'] :
     T extends boolean ? GeoStylerBooleanFunction['name'] :
     unknown ;
-  args: Expression<PropertyValue>[];
+  args?: Expression<PropertyType>[];
 };
 
 /**
  * Expressions can be a literal value, a property name or a function call.
  */
-export type Expression<T extends PropertyValue> = T | PropertyName | FunctionCall<T> ;
+export type Expression<T extends PropertyType> = T | FunctionCall<T> ;
 
 /**
  * The type of the Style.
@@ -64,7 +44,7 @@ export type StyleType = 'Point' | 'Fill' | 'Line' | 'Raster';
 /**
  * A value of a property of the data.
  */
-export type PropertyValue = string | number | boolean | null;
+export type PropertyType = string | number | boolean | null;
 
 /**
  * The possible Operators used for comparison Filters.

--- a/style.ts
+++ b/style.ts
@@ -45,9 +45,9 @@ export type Expression<T extends PropertyType> =
 export type StyleType = 'Point' | 'Fill' | 'Line' | 'Raster';
 
 /**
- * A value of a property of the data.
+ * A datatype of a property of the data.
  */
-export type PropertyType = string | number | boolean | null;
+export type PropertyType = string | number | boolean | unknown;
 
 /**
  * The possible Operators used for comparison Filters.
@@ -85,7 +85,7 @@ export type RangeFilter = [
  */
 export type ComparisonFilter = [
   ComparisonOperator,
-  Expression<string | number | boolean>,
+  Expression<string>,
   Expression<string | number | boolean>
 ] | RangeFilter;
 

--- a/style.ts
+++ b/style.ts
@@ -105,7 +105,7 @@ export type NegationFilter = [
   Filter
 ];
 
-export type Filter = ComparisonFilter | NegationFilter | CombinationFilter | GeoStylerBooleanFunction;
+export type Filter = ComparisonFilter | NegationFilter | CombinationFilter;
 
 /**
  * The kind of the Symbolizer

--- a/style.ts
+++ b/style.ts
@@ -6,11 +6,11 @@ export interface ScaleDenominator {
    * Minimum value of the ScaleDenominator. The value is inclusive.
    *
    */
-  min?: number;
+  min?: Expression<number>;
   /**
    * Maximum value of the ScaleDenominator. The value is exclusive.
    */
-  max?: number;
+  max?: Expression<number>;
 }
 
 /**
@@ -33,28 +33,28 @@ export interface LiteralValue<T> extends AbstractExpression {
  */
 export interface PropertyName extends AbstractExpression {
   type: 'property';
-  name: string;
+  name: Expression<string>;
 };
 
 /**
  * Expression that evaluates to the result of a function
  * call on a list of argument expressions.
  */
-export interface FunctionCall extends AbstractExpression {
+export interface FunctionCall<T> extends AbstractExpression {
   type: 'functioncall';
-  name: string;
-  args: Expression[];
+  name: Expression<string>;
+  args: Expression<PropertyValue>[];
 };
 
 /**
  * Expressions can be a literal value, a property name or a function call.
  */
-export type Expression = LiteralValue<string> |
-  LiteralValue<number> |
-  LiteralValue<boolean> |
-  LiteralValue<null> |
+export type Expression<T extends PropertyValue> =
+  T |
+  LiteralValue<T> |
   PropertyName |
-  FunctionCall;
+  // TODO: This should be a GeoStylerFunction (from functions.ts). Fix the typing here.
+  FunctionCall<T>;
 
 /**
  * The type of the Style.
@@ -115,7 +115,7 @@ export type StrMatchesFunctionFilter = [
  * See https://geoserver-pdf.readthedocs.io/en/latest/filter/function_reference.html#transformation-functions
  * for a detailed description.
  */
-export interface CategorizeFunctionFilter extends FunctionCall {
+export interface CategorizeFunctionFilter extends FunctionCall<string> {
   name: CategorizeFunctionOperator;
 };
 
@@ -127,7 +127,12 @@ export type FunctionFilter = StrMatchesFunctionFilter;
 /**
  * A Filter that checks if a property is in a range of two values (inclusive).
  */
-export type RangeFilter = ['<=x<=', Expression | FunctionFilter | string, number | Expression, number | Expression];
+export type RangeFilter = [
+  '<=x<=',
+  FunctionFilter | Expression<string | number>,
+  Expression<number>,
+  Expression<number>
+];
 
 /**
  * A ComparisonFilter compares a value of an object (by key) with an expected
@@ -135,8 +140,8 @@ export type RangeFilter = ['<=x<=', Expression | FunctionFilter | string, number
  */
 export type ComparisonFilter = [
   ComparisonOperator,
-  Expression | string | number,
-  Expression | string | number
+  Expression<string | number>,
+  Expression<string | number>
 ] | RangeFilter;
 
 /**
@@ -173,16 +178,16 @@ export interface BaseSymbolizer {
   /**
    * A color defined as a hex-color string.
    */
-  color?: string | Expression;
+  color?: Expression<string>;
   /**
    * Determines the total opacity for the Symbolizer.
    * A value between 0 and 1. 0 is none opaque and 1 is full opaque.
    */
-  opacity?: number | Expression;
+  opacity?: Expression<number>;
   /**
    * Defines whether the Symbolizer should be visibile or not.
    */
-  visibility?: boolean | Expression;
+  visibility?: Expression<boolean>;
 }
 
 /**
@@ -193,12 +198,12 @@ export interface BasePointSymbolizer extends BaseSymbolizer {
    * This is a property relevant if using tiled datasets.
    * If true, the symbols will not cross tile edges to avoid mutual collisions.
    */
-  avoidEdges?: boolean | Expression;
+  avoidEdges?: Expression<boolean>;
   /**
    * The offset of the Symbolizer as [x, y] coordinates. Positive values indicate
    * right and down, while negative values indicate left and up.
    */
-  offset?: [number | Expression, number | Expression];
+  offset?: [Expression<number>, Expression<number>];
   /**
    * Property relevant for mapbox-styles.
    * Compare https://docs.mapbox.com/mapbox-gl-js/style-spec/#paint-symbol-icon-translate-anchor
@@ -247,7 +252,7 @@ export interface MarkSymbolizer extends BasePointSymbolizer {
    * The radius of the Symbolizer. Values describing the full size of the Symbolizer
    * have to be divided by two (pixels if radiusUnit is not defined).
    */
-  radius?: number | Expression;
+  radius?: Expression<number>;
   /**
    * Unit to use for the radius.
    */
@@ -255,25 +260,25 @@ export interface MarkSymbolizer extends BasePointSymbolizer {
   /**
    * The rotation of the Symbolizer in degrees. Value should be between 0 and 360.
    */
-  rotate?: number | Expression;
+  rotate?: Expression<number>;
   /**
    * The opacity of the fill. A value between 0 and 1.
    * 0 is none opaque and 1 is full opaque.
    */
-  fillOpacity?: number | Expression;
+  fillOpacity?: Expression<number>;
   /**
    * The color of the stroke represented as a hex-color string.
    */
-  strokeColor?: string | Expression;
+  strokeColor?: Expression<string>;
   /**
    * The opacity of the stroke. A value between 0 and 1.
    * 0 is none opaque and 1 is full opaque.
    */
-  strokeOpacity?: number | Expression;
+  strokeOpacity?: Expression<number>;
   /**
    * The width of the stroke (pixels if strokeWidthUnit is not defined).
    */
-  strokeWidth?: number | Expression;
+  strokeWidth?: Expression<number>;
   /**
    * Unit to use for the strokeWidth.
    */
@@ -282,7 +287,7 @@ export interface MarkSymbolizer extends BasePointSymbolizer {
    * Amount to blur the Symbolizer. 1 blurs the Symbolizer such that only the
    * centerpoint has full opacity. Mostly relevant for circles.
    */
-  blur?: number | Expression;
+  blur?: Expression<number>;
   /**
    * Property relevant for mapbox-styles.
    * Compare https://docs.mapbox.com/mapbox-gl-js/style-spec/#paint-circle-circle-pitch-alignment
@@ -305,7 +310,7 @@ export interface TextSymbolizer extends BasePointSymbolizer {
    * If true, the text will be visible even if it collides with other previously
    * drawn symbols.
    */
-  allowOverlap?: boolean | Expression;
+  allowOverlap?: Expression<boolean>;
   /**
    * The anchor position of the label referred to the center of the geometry.
    */
@@ -315,24 +320,24 @@ export interface TextSymbolizer extends BasePointSymbolizer {
    * from the dataset.
    * e.g.: "Name {{country_name}}"
    */
-  label?: string;
+  label?: Expression<string>;
   /**
    * An Array of fonts. Comparable to https://www.w3schools.com/cssref/pr_font_font-family.asp
    */
-  font?: string[];
+  font?: Expression<string>[];
   /**
    * The halo's fadeout distance towards the outside.
    */
-  haloBlur?: number | Expression;
+  haloBlur?: Expression<number>;
   /**
    * The color of the text's halo, which helps it stand out from backgrounds
    * represented as a hex-color string.
    */
-  haloColor?: string | Expression;
+  haloColor?: Expression<string>;
   /**
    * Distance of halo to the font outline (pixels if haloWidthUnit is not defined).
    */
-  haloWidth?: number | Expression;
+  haloWidth?: Expression<number>;
   /**
    * Unit to use for the haloWidth.
    */
@@ -344,11 +349,11 @@ export interface TextSymbolizer extends BasePointSymbolizer {
   /**
    * If true, the text will be kept upright.
    */
-  keepUpright?: boolean | Expression;
+  keepUpright?: Expression<boolean>;
   /**
    * Sets the spacing between text characters (pixels if letterSpacingUnit is not defined).
    */
-  letterSpacing?: number | Expression;
+  letterSpacing?: Expression<number>;
   /**
    * Unit to use for the letterSpacing.
    */
@@ -357,7 +362,7 @@ export interface TextSymbolizer extends BasePointSymbolizer {
    * Sets the line height (pixels if lineHeightUnit is not defined).
    * 'em' -> fontsize
    */
-  lineHeight?: number | Expression;
+  lineHeight?: Expression<number>;
   /**
    * Unit to use for the lineHeight.
    * 'em' -> fontsize
@@ -366,22 +371,22 @@ export interface TextSymbolizer extends BasePointSymbolizer {
   /**
    * Maximum angle change between adjacent characters in degrees.
    */
-  maxAngle?: number | Expression;
+  maxAngle?: Expression<number>;
   /**
    * The maximum line width for text wrapping.
    */
-  maxWidth?: number | Expression;
+  maxWidth?: Expression<number>;
   /**
    * Property relevant for mapbox-styles.
    * If true, icons will display without their corresponding text when the text
    * collides with other symbols and the icon does not.
    */
-  optional?: boolean | Expression;
+  optional?: Expression<boolean>;
   /**
    * Size of the additional area around the text bounding box used for detecting
    * symbol collisions.
    */
-  padding?: number | Expression;
+  padding?: Expression<number>;
   /**
    * Property relevant for mapbox-styles.
    * Compare https://docs.mapbox.com/mapbox-gl-js/style-spec/#layout-symbol-text-pitch-alignment
@@ -390,7 +395,7 @@ export interface TextSymbolizer extends BasePointSymbolizer {
   /**
    * The rotation of the Symbolizer in degrees. Value should be between 0 and 360.
    */
-  rotate?: number | Expression;
+  rotate?: Expression<number>;
   /**
    * Property relevant for mapbox-styles.
    * Compare https://docs.mapbox.com/mapbox-gl-js/style-spec/#layout-symbol-text-rotation-alignment
@@ -399,7 +404,7 @@ export interface TextSymbolizer extends BasePointSymbolizer {
   /**
    * The fontsize in pixels.
    */
-  size?: number | Expression;
+  size?: Expression<number>;
   /**
    * Specifies how to capitalize text, similar to the CSS text-transform property.
    */
@@ -426,7 +431,7 @@ export interface IconSymbolizer extends BasePointSymbolizer {
    * If true, the icon will be visible even if it collides with other previously
    * drawn symbols.
    */
-  allowOverlap?: boolean | Expression;
+  allowOverlap?: Expression<boolean>;
   /**
    * Part of the icon placed closest to the anchor. This may conflict with a set
    * offset.
@@ -435,16 +440,16 @@ export interface IconSymbolizer extends BasePointSymbolizer {
   /**
    * The halo's fadeout distance towards the outside.
    */
-  haloBlur?: number | Expression;
+  haloBlur?: Expression<number>;
   /**
    * The color of the icons halo, which helps it stand out from backgrounds represented
    * as a hex-color string.
    */
-  haloColor?: string | Expression;
+  haloColor?: Expression<string>;
   /**
    * Distance of halo to the font outline (pixels if haloWidthUnit is not defined).
    */
-  haloWidth?: number | Expression;
+  haloWidth?: Expression<number>;
   /**
    * Unit to use for the haloWidth.
    */
@@ -452,7 +457,7 @@ export interface IconSymbolizer extends BasePointSymbolizer {
   /**
    * A path/URL to the icon image file.
    */
-  image?: string | Expression;
+  image?: Expression<string>;
   /**
    * An optional configuration for the image format as MIME type.
    * This might be needed if the image(path) has no filending specified. e.g. http://myserver/getImage
@@ -461,17 +466,17 @@ export interface IconSymbolizer extends BasePointSymbolizer {
   /**
    * If true, the icon will be kept upright.
    */
-  keepUpright?: boolean | Expression;
+  keepUpright?: Expression<boolean>;
   /**
    * Property relevant for mapbox-styles.
    * If true, text will display without their corresponding icons when the icon
    * collides with other symbols and the text does not.
    */
-  optional?: boolean | Expression;
+  optional?: Expression<boolean>;
   /**
    * Size of the additional area around the icon used for detecting symbol collisions.
    */
-  padding?: number | Expression;
+  padding?: Expression<number>;
   /**
    * Property relevant for mapbox-styles.
    * Compare https://docs.mapbox.com/mapbox-gl-js/style-spec/#layout-symbol-icon-pitch-alignment
@@ -480,7 +485,7 @@ export interface IconSymbolizer extends BasePointSymbolizer {
   /**
    * The rotation of the Symbolizer in degrees. Value should be between 0 and 360.
    */
-  rotate?: number | Expression;
+  rotate?: Expression<number>;
   /**
    * Property relevant for mapbox-styles.
    * Compare https://docs.mapbox.com/mapbox-gl-js/style-spec/#layout-symbol-icon-rotation-alignment
@@ -489,7 +494,7 @@ export interface IconSymbolizer extends BasePointSymbolizer {
   /**
    * The Symbolizer size (pixels if sizeUnit is not defined).
    */
-  size?: number | Expression;
+  size?: Expression<number>;
   /**
    * Unit to use for the size.
    */
@@ -503,7 +508,7 @@ export interface IconSymbolizer extends BasePointSymbolizer {
    * Property relevant for mapbox-styles.
    * Compare https://docs.mapbox.com/mapbox-gl-js/style-spec/#layout-symbol-icon-text-fit-padding
    */
-  textFitPadding?: [number, number, number, number];
+  textFitPadding?: [Expression<number>, Expression<number>, Expression<number>, Expression<number>];
 }
 
 /**
@@ -514,26 +519,26 @@ export interface FillSymbolizer extends BaseSymbolizer {
   /**
    * Whether the fill should be antialiased or not .
    */
-  antialias?: boolean | Expression;
+  antialias?: Expression<boolean>;
   /**
    * The opacity of the fill. A value between 0 and 1.
    * 0 is none opaque and 1 is full opaque.
    */
-  fillOpacity?: number | Expression;
+  fillOpacity?: Expression<number>;
   /**
    * The outline color as a hex-color string. Matches the value of fill-color if
    * unspecified.
    */
-  outlineColor?: string | Expression;
+  outlineColor?: Expression<string>;
   /**
    * The opacity of the outline. A value between 0 and 1.
    * 0 is none opaque and 1 is full opaque.
    */
-  outlineOpacity?: number | Expression;
+  outlineOpacity?: Expression<number>;
   /**
    * The outline width (pixels if outlineWidthUnit is not defined).
    */
-  outlineWidth?: number | Expression;
+  outlineWidth?: Expression<number>;
   /**
    * Unit to use for the outlineWidth.
    */
@@ -544,7 +549,7 @@ export interface FillSymbolizer extends BaseSymbolizer {
    * numbers (second, fourth, etc) determine the length in pixels to blank out
    * the line. Default is an unbroken line.
    */
-  outlineDasharray?: number[];
+  outlineDasharray?: Expression<number>[];
   /**
    * Renders the fill of the polygon with a repeated pattern of PointSymbolizer.
    */
@@ -561,7 +566,7 @@ export type GraphicType = 'Mark' | 'Icon';
  */
 export interface LineSymbolizer extends BaseSymbolizer {
   kind: 'Line';
-  blur?: number | Expression;
+  blur?: Expression<number>;
   /**
    * Determines how lines are rendered at their ends. Possible values are butt
    * (sharp square edge), round (rounded edge), and square (slightly elongated
@@ -574,17 +579,17 @@ export interface LineSymbolizer extends BaseSymbolizer {
    * numbers (second, fourth, etc) determine the length in pixels to blank out
    * the line. Default is an unbroken line.
    */
-  dasharray?: number[];
+  dasharray?: Expression<number>[];
   /**
    * Number of pixels into the dasharray to offset the drawing of the dash,
    * used to shift the location of the lines and gaps in a dash.
    */
-  dashOffset?: number | Expression;
+  dashOffset?: Expression<number>;
   /**
    * Draws a line casing outside of a line's actual path. Value indicates the
    * width of the inner gap (pixels if gapWidthUnit is not defined).
    */
-  gapWidth?: number | Expression;
+  gapWidth?: Expression<number>;
   /**
    * Unit to use for the gapWidth.
    */
@@ -610,21 +615,21 @@ export interface LineSymbolizer extends BaseSymbolizer {
   /**
    * Used to automatically convert miter joins to bevel joins for sharp angles.
    */
-  miterLimit?: number | Expression;
+  miterLimit?: Expression<number>;
   /**
    * If present, it makes the renderer draw a line parallel to the original one,
    * at the given distance. When applied on lines, positive values generate a
    * parallel line on the left hand side, negative values on the right hand side.
    */
-  perpendicularOffset?: number | Expression;
+  perpendicularOffset?: Expression<number>;
   /**
    * Used to automatically convert round joins to miter joins for shallow angles.
    */
-  roundLimit?: number | Expression;
+  roundLimit?: Expression<number>;
   /**
    * Distance between two symbol anchors (pixels if spacingUnit is not defined).
    */
-  spacing?: number | Expression;
+  spacing?: Expression<number>;
   /**
    * Unit to use for the spacing.
    * 'em' -> fontsize
@@ -633,7 +638,7 @@ export interface LineSymbolizer extends BaseSymbolizer {
   /**
    * The width of the Line (pixels if widthUnit is not defined).
    */
-  width?: number | Expression;
+  width?: Expression<number>;
   /**
    * Unit to use for the width.
    */
@@ -649,10 +654,10 @@ export type PointSymbolizer = IconSymbolizer | MarkSymbolizer | TextSymbolizer;
  * A single entry for the ColorMap.
  */
 export interface ColorMapEntry {
-  color: string;
-  quantity?: number;
-  label?: string;
-  opacity?: number;
+  color: Expression<string>;
+  quantity?: Expression<number>;
+  label?: Expression<string>;
+  opacity?: Expression<number>;
 }
 
 /**
@@ -666,7 +671,7 @@ export type ColorMapType = 'ramp' | 'intervals' | 'values';
 export interface ColorMap {
   type: ColorMapType;
   colorMapEntries?: ColorMapEntry[];
-  extended?: boolean;
+  extended?: Expression<boolean>;
 }
 
 /**
@@ -674,14 +679,14 @@ export interface ColorMap {
  */
 export interface ContrastEnhancement {
   enhancementType?: 'normalize' | 'histogram';
-  gammaValue?: number;
+  gammaValue?: Expression<number>;
 }
 
 /**
  * A Channel defines the properties for a color channel.
  */
 export interface Channel {
-  sourceChannelName?: string;
+  sourceChannelName?: Expression<string>;
   contrastEnhancement?: ContrastEnhancement;
 }
 
@@ -708,18 +713,18 @@ export type ChannelSelection = RGBChannel | GrayChannel;
  */
 export interface RasterSymbolizer {
   kind: 'Raster';
-  visibility?: boolean;
-  opacity?: number;
+  visibility?: Expression<boolean>;
+  opacity?: Expression<number>;
   colorMap?: ColorMap;
   channelSelection?: ChannelSelection;
   contrastEnhancement?: ContrastEnhancement;
-  hueRotate?: number;
-  brightnessMin?: number;
-  brightnessMax?: number;
-  saturation?: number;
-  contrast?: number;
+  hueRotate?: Expression<number>;
+  brightnessMin?: Expression<number>;
+  brightnessMax?: Expression<number>;
+  saturation?: Expression<number>;
+  contrast?: Expression<number>;
   resampling?: 'linear' | 'nearest';
-  fadeDuration?: number;
+  fadeDuration?: Expression<number>;
 }
 
 /**

--- a/style.ts
+++ b/style.ts
@@ -35,27 +35,26 @@ export interface PropertyName extends AbstractExpression {
   name: Expression<string>;
 };
 
-type FunctionCallType = 'stringfunction' | 'numberfunction' | 'booleanfunction' | 'voidfunction';
-
 /**
  * Expression that evaluates to the result of a function
  * call on a list of argument expressions.
  */
-export interface FunctionCall extends AbstractExpression {
-  type: FunctionCallType;
-  name: GeoStylerStringFunction['name'] | GeoStylerNumberFunction['name'] | GeoStylerBooleanFunction['name'];
+export interface FunctionCall<T> extends AbstractExpression {
+  type: T extends string ? 'stringfunction' :
+    T extends number ? 'numberfunction' :
+    T extends boolean ? 'booleanfunction' :
+    'voidfunction';
+  name: T extends string ? GeoStylerStringFunction['name'] :
+    T extends number ? GeoStylerNumberFunction['name'] :
+    T extends boolean ? GeoStylerBooleanFunction['name'] :
+    unknown ;
   args: Expression<PropertyValue>[];
 };
 
 /**
  * Expressions can be a literal value, a property name or a function call.
  */
-export type Expression<T extends PropertyValue> =
-  T extends string ? PropertyName | T | GeoStylerStringFunction :
-  T extends number ? PropertyName | T | GeoStylerNumberFunction :
-  T extends boolean ? PropertyName | T | GeoStylerBooleanFunction :
-  T extends null | undefined ? null | undefined :
-  PropertyName | T;
+export type Expression<T extends PropertyValue> = T | PropertyName | FunctionCall<T> ;
 
 /**
  * The type of the Style.

--- a/style.ts
+++ b/style.ts
@@ -26,15 +26,18 @@ export interface ScaleDenominator {
 export interface FunctionCall<T> {
   name: T extends string ? GeoStylerStringFunction['name'] :
     T extends number ? GeoStylerNumberFunction['name'] :
-    T extends boolean ? GeoStylerBooleanFunction['name'] :
-    unknown ;
-  args?: Expression<PropertyType>[];
+    GeoStylerBooleanFunction['name'];
+  args: Expression<PropertyType>[];
 };
 
 /**
  * Expressions can be a literal value, a property name or a function call.
  */
-export type Expression<T extends PropertyType> = T | FunctionCall<T> ;
+export type Expression<T extends PropertyType> =
+  T extends string ? GeoStylerStringFunction | T:
+  T extends number ? GeoStylerNumberFunction | T :
+  T extends boolean ? GeoStylerBooleanFunction | T :
+  T;
 
 /**
  * The type of the Style.

--- a/typeguards.ts
+++ b/typeguards.ts
@@ -19,7 +19,6 @@ import {
   ComparisonOperator,
   FillSymbolizer,
   Filter,
-  FunctionFilter,
   GrayChannel,
   IconSymbolizer,
   LineSymbolizer,
@@ -32,22 +31,15 @@ import {
   RGBChannel,
   Rule,
   ScaleDenominator,
-  StrMatchesFunctionOperator,
   TextSymbolizer,
-  CategorizeFunctionFilter,
-  CategorizeFunctionOperator,
   Expression,
   FunctionCall,
-  LiteralValue,
-  PropertyName
+  PropertyName,
+  GeoStylerBooleanFunction
 } from './index';
 
-export const isExpression = (got: any): got is Expression => {
+export const isExpression = (got: any): got is Expression<any> => {
   return isFunctionCall(got) ||
-  isLiteralStringValue(got) ||
-  isLiteralNumberValue(got) ||
-  isLiteralBooleanValue(got) ||
-  isLiteralNullValue(got) ||
   isPropertyName(got);
 };
 
@@ -58,45 +50,6 @@ export const isFunctionCall = (got: any): got is FunctionCall => {
     got.hasOwnProperty('args') &&
     Array.isArray(got.args) &&
     got.args.every((arg: any) => isExpression(arg));
-};
-
-export const isLiteralValue = (val: any): boolean => {
-  return isLiteralStringValue(val) ||
-  isLiteralNumberValue(val) ||
-  isLiteralBooleanValue(val) ||
-  isLiteralNullValue(val);
-};
-
-export const isLiteralStringValue = (got: any): got is LiteralValue<string> => {
-  return got.type === 'literal' &&
-    got.hasOwnProperty('value') &&
-    (
-      _isString(got.value)
-    );
-};
-
-export const isLiteralNumberValue = (got: any): got is LiteralValue<number> => {
-  return got.type === 'literal' &&
-    got.hasOwnProperty('value') &&
-    (
-      _isNumber(got.value)
-    );
-};
-
-export const isLiteralBooleanValue = (got: any): got is LiteralValue<boolean> => {
-  return got.type === 'literal' &&
-    got.hasOwnProperty('value') &&
-    (
-      _isBoolean(got.value)
-    );
-};
-
-export const isLiteralNullValue = (got: any): got is LiteralValue<null> => {
-  return got.type === 'literal' &&
-    got.hasOwnProperty('value') &&
-    (
-      _isNull(got.value)
-    );
 };
 
 export const isPropertyName = (got: any): got is PropertyName => {
@@ -121,7 +74,6 @@ export const isScaleDenominator = (got: any): got is ScaleDenominator => {
 export const isOperator = (got: any): got is Operator => {
   return isComparisonOperator(got) ||
     isCombinationOperator(got) ||
-    isStrMatchesFunctionOperator(got) ||
     isNegationOperator(got);
 };
 export const isComparisonOperator = (got: any): got is ComparisonOperator => {
@@ -133,18 +85,12 @@ export const isCombinationOperator = (got: any): got is CombinationOperator => {
 export const isNegationOperator = (got: any): got is NegationOperator => {
   return got === '!';
 };
-export const isStrMatchesFunctionOperator = (got: any): got is StrMatchesFunctionOperator => {
-  return got === 'FN_strMatches';
-};
-export const isCategorizeFunctionOperator = (got: any): got is CategorizeFunctionOperator => {
-  return got === 'Categorize';
-};
 
 // Filters
 export const isFilter = (got: any): got is Filter => {
   return isComparisonFilter(got) ||
     isCombinationFilter(got) ||
-    isFunctionFilter(got) ||
+    isGeoStylerBooleanFunction(got) ||
     isNegationFilter(got);
 };
 export const isComparisonFilter = (got: any): got is ComparisonFilter => {
@@ -152,7 +98,7 @@ export const isComparisonFilter = (got: any): got is ComparisonFilter => {
   return Array.isArray(got) &&
     got.length === expectedLength &&
     isComparisonOperator(got[0]) &&
-    (isFunctionFilter(got[1]) || _isString(got[1])) &&
+    (isGeoStylerBooleanFunction(got[1]) || _isString(got[1])) &&
     isPropertyValue(got[2]) &&
     (got[0] !== '<=x<=' || _isNumber(got[3]));
 };
@@ -167,18 +113,6 @@ export const isNegationFilter = (got: any): got is NegationFilter => {
     got.length === 2 &&
     isNegationOperator(got[0]) &&
     isFilter(got[1]);
-};
-export const isFunctionFilter = (got: any): got is FunctionFilter => {
-  return Array.isArray(got) &&
-    got.length === 3 &&
-    isStrMatchesFunctionOperator(got[0]) &&
-    _isString(got[1]) &&
-    _isRegExp(got[2]);
-};
-
-// Function filters
-export const isCategorizeFunctionFilter = (got: any): got is CategorizeFunctionFilter => {
-  return isFunctionCall(got) && isCategorizeFunctionOperator(got.name);
 };
 
 // Symbolizers
@@ -231,4 +165,15 @@ export const isRgbChannel = (channels: ChannelSelection): channels is RGBChannel
  */
 export const isGrayChannel = (channels: ChannelSelection): channels is GrayChannel => {
   return (channels as GrayChannel).grayChannel !== undefined;
+};
+
+// Functions
+export const isGeoStylerNumberFunction = (got: any): got is GeoStylerBooleanFunction => {
+  return got.type === 'numberfunction';
+};
+export const isGeoStylerStringFunction = (got: any): got is GeoStylerBooleanFunction => {
+  return got.type === 'stringfunction';
+};
+export const isGeoStylerBooleanFunction = (got: any): got is GeoStylerBooleanFunction => {
+  return got.type === 'booleanfunction';
 };

--- a/typeguards.ts
+++ b/typeguards.ts
@@ -168,10 +168,10 @@ export const isGrayChannel = (channels: ChannelSelection): channels is GrayChann
 };
 
 // Functions
-export const isGeoStylerNumberFunction = (got: any): got is GeoStylerBooleanFunction => {
+export const isGeoStylerNumberFunction = (got: any): got is GeoStylerNumberFunction => {
   return got.type === 'numberfunction';
 };
-export const isGeoStylerStringFunction = (got: any): got is GeoStylerBooleanFunction => {
+export const isGeoStylerStringFunction = (got: any): got is GeoStylerStringFunction => {
   return got.type === 'stringfunction';
 };
 export const isGeoStylerBooleanFunction = (got: any): got is GeoStylerBooleanFunction => {

--- a/typeguards.ts
+++ b/typeguards.ts
@@ -37,7 +37,8 @@ import {
   GeoStylerBooleanFunction,
   GeoStylerNumberFunction,
   GeoStylerStringFunction,
-  GeoStylerUnknownFunction
+  GeoStylerUnknownFunction,
+  GeoStylerFunction
 } from './index';
 
 export const isExpression = (got: any): got is Expression<any> => {
@@ -228,4 +229,11 @@ export const isGeoStylerUnknownFunction = (got: any): got is GeoStylerUnknownFun
   return [
     'property',
   ].includes(got.name);
+};
+
+export const isGeoStylerFunction = (got: any): got is GeoStylerFunction => {
+  return isGeoStylerBooleanFunction(got) ||
+    isGeoStylerNumberFunction(got) ||
+    isGeoStylerStringFunction(got) ||
+    isGeoStylerUnknownFunction(got);
 };

--- a/typeguards.ts
+++ b/typeguards.ts
@@ -26,7 +26,7 @@ import {
   NegationFilter,
   NegationOperator,
   Operator,
-  PropertyValue,
+  PropertyType,
   RasterSymbolizer,
   RGBChannel,
   Rule,
@@ -34,13 +34,13 @@ import {
   TextSymbolizer,
   Expression,
   FunctionCall,
-  PropertyName,
-  GeoStylerBooleanFunction
+  GeoStylerBooleanFunction,
+  GeoStylerNumberFunction,
+  GeoStylerStringFunction
 } from './index';
 
 export const isExpression = (got: any): got is Expression<any> => {
-  return isFunctionCall(got) ||
-  isPropertyName(got);
+  return isFunctionCall(got) || isPropertyType(got);
 };
 
 export const isFunctionCall = (got: any): got is FunctionCall<any> => {
@@ -52,14 +52,8 @@ export const isFunctionCall = (got: any): got is FunctionCall<any> => {
     got.args.every((arg: any) => isExpression(arg));
 };
 
-export const isPropertyName = (got: any): got is PropertyName => {
-  return got.type === 'property' &&
-    got.hasOwnProperty('name') &&
-    _isString(got.name);
-};
-
 // PropertyValue
-export const isPropertyValue = (got: any): got is PropertyValue => {
+export const isPropertyType = (got: any): got is PropertyType => {
   return _isString(got) || _isNumber(got) || _isBoolean(got) || got === null;
 };
 
@@ -99,7 +93,7 @@ export const isComparisonFilter = (got: any): got is ComparisonFilter => {
     got.length === expectedLength &&
     isComparisonOperator(got[0]) &&
     (isGeoStylerBooleanFunction(got[1]) || _isString(got[1])) &&
-    isPropertyValue(got[2]) &&
+    isPropertyType(got[2]) &&
     (got[0] !== '<=x<=' || _isNumber(got[3]));
 };
 export const isCombinationFilter = (got: any): got is CombinationFilter => {

--- a/typeguards.ts
+++ b/typeguards.ts
@@ -36,7 +36,8 @@ import {
   FunctionCall,
   GeoStylerBooleanFunction,
   GeoStylerNumberFunction,
-  GeoStylerStringFunction
+  GeoStylerStringFunction,
+  GeoStylerUnknownFunction
 } from './index';
 
 export const isExpression = (got: any): got is Expression<any> => {
@@ -163,11 +164,68 @@ export const isGrayChannel = (channels: ChannelSelection): channels is GrayChann
 
 // Functions
 export const isGeoStylerNumberFunction = (got: any): got is GeoStylerNumberFunction => {
-  return got.type === 'numberfunction';
+  return [
+    'abs',
+    'acos',
+    'asin',
+    'atan',
+    'atan2',
+    'ceil',
+    'cos',
+    'exp',
+    'floor',
+    'log',
+    'max',
+    'min',
+    'modulo',
+    'pi',
+    'pow',
+    'random',
+    'rint',
+    'round',
+    'sin',
+    'sqrt',
+    'strIndexOf',
+    'strLastIndexOf',
+    'strLength',
+    'tan',
+    'toDegrees',
+    'toRadians'
+  ].includes(got.name);
 };
+
 export const isGeoStylerStringFunction = (got: any): got is GeoStylerStringFunction => {
-  return got.type === 'stringfunction';
+  return [
+    'numberFormat',
+    'strAbbreviate',
+    'strCapitalize',
+    'strConcat',
+    'strDefaultIfBlank',
+    'strReplace',
+    'strStripAccents',
+    'strSubstring',
+    'strSubstringStart',
+    'strToLowerCase',
+    'strToUpperCase',
+    'strTrim'
+  ].includes(got.name);
 };
+
 export const isGeoStylerBooleanFunction = (got: any): got is GeoStylerBooleanFunction => {
-  return got.type === 'booleanfunction';
+  return [
+    'between',
+    'double2bool',
+    'in',
+    'parseBoolean',
+    'strEndsWith',
+    'strEqualsIgnoreCase',
+    'strMatches',
+    'strStartsWith'
+  ].includes(got.name);
+};
+
+export const isGeoStylerUnknownFunction = (got: any): got is GeoStylerUnknownFunction => {
+  return [
+    'property',
+  ].includes(got.name);
 };

--- a/typeguards.ts
+++ b/typeguards.ts
@@ -43,7 +43,7 @@ export const isExpression = (got: any): got is Expression<any> => {
   isPropertyName(got);
 };
 
-export const isFunctionCall = (got: any): got is FunctionCall => {
+export const isFunctionCall = (got: any): got is FunctionCall<any> => {
   return got.type === 'functioncall' &&
     got.hasOwnProperty('name') &&
     _isString(got.name) &&


### PR DESCRIPTION
This introduces the typing of functions for the `geostyler-style`.
This might help to create the parsers and to improve the comparability between the different outputs.

~It also makes the `Expression` generic to define it's "return value". 
This ensures to have the right literal at all time.~

It also simplifies the `Expression` typing by removing `AbstractExpression`, `PropertyName` and `LiteralValue`.

TODOs: 

~~- [ ] Fix typing/union of `GeoStylerFunction`~~ Replaced with `GeostylerNumberFunction`, `GeoStylerStringFunction`, …
- [ ] Doublecheck all modifications in the `style.ts`: Is every use of `Expression<?>` correct?
- [x] Reduce amount of functions. The capabilities offered way more then the GeoServer docs.
- [x] The feedback of TypeScript is currently misleading. Let's see if we can do this better. --> should be ok for now