### PR TITLE
Allow Expression<null> in ComparisonFilter

### DIFF
--- a/examples/filter.ts
+++ b/examples/filter.ts
@@ -1,0 +1,35 @@
+import { Style } from '../index';
+
+const pointSimplePoint: Style = {
+  name: 'Simple Point Filter',
+  rules: [{
+    filter: ['&&',
+      ['==', 'NAME', 'New York'],
+      ['==', 'TEST_BOOL', 'true'],
+      ['==', 'TEST', null],
+      ['*=', 'TEST2', '*York*'],
+      ['*=', 'TEST1', '*New*'],
+      ['!', ['>', 'POPULATION', '100000']],
+      ['||',
+        ['==', 'TEST2', '1'],
+        ['==', 'TEST2', '2']
+      ],
+      ['<=x<=', 'TEST3', 1, 5]
+    ],
+    name: 'Small populated New Yorks',
+    scaleDenominator: {
+      'max': 20000,
+      'min': 10000
+    },
+    symbolizers: [{
+      'kind': 'Mark',
+      'wellKnownName': 'circle',
+      'color': '#FF0000',
+      'radius': 3,
+      'strokeColor': '#000000',
+      'strokeWidth': 2
+    }]
+  }]
+};
+
+export default pointSimplePoint;

--- a/style.ts
+++ b/style.ts
@@ -35,7 +35,7 @@ export interface FunctionCall<T> {
  * Expressions can be a literal value, a property name or a function call.
  */
 export type Expression<T extends PropertyType> =
-  T extends string ? GeoStylerStringFunction | T:
+  T extends string ? GeoStylerStringFunction | T :
   T extends number ? GeoStylerNumberFunction | T :
   T extends boolean ? GeoStylerBooleanFunction | T :
   T;
@@ -87,8 +87,8 @@ export type RangeFilter = [
  */
 export type ComparisonFilter = [
   ComparisonOperator,
-  Expression<string | number | boolean>,
-  Expression<string | number | boolean>
+  Expression<string | number | boolean | null>,
+  Expression<string | number | boolean | null>
 ] | RangeFilter;
 
 /**


### PR DESCRIPTION
This allows `ComparionsFilter`s to be created with `Expression`s resolving to `null`