### PR TITLE
Add two missing Expression types

### DIFF
--- a/style.ts
+++ b/style.ts
@@ -508,11 +508,11 @@ export interface FillSymbolizer extends BaseSymbolizer {
   /**
    * The Captype for the outLine.
    */
-  outlineCap?: CapType;
+  outlineCap?: Expression<CapType>;
   /**
    * The JoinType for the outLine.
    */
-  outlineJoin?: JoinType;
+  outlineJoin?: Expression<JoinType>;
   /**
    * Unit to use for the outlineWidth.
    */


### PR DESCRIPTION
This adds two missing `Expression<T>` types.