### PR TITLE
Fixes `isGeoStylerBooleanFunction`

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -12,6 +12,9 @@
                 "sourceChannelName": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -71,7 +74,16 @@
                 "extended": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fall"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fany"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
@@ -80,7 +92,28 @@
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                         },
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FequalTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThanOrEqualTo"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThanOrEqualTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fnot"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnotEqualTo"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
@@ -104,7 +137,59 @@
                     "description": "Expressions can be a literal value, a property name or a function call."
                 },
                 "type": {
-                    "$ref": "http://geostyler/geostyler-style.json#/definitions/ColorMapType"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                        },
+                        {
+                            "enum": [
+                                "intervals",
+                                "ramp",
+                                "values"
+                            ],
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Expressions can be a literal value, a property name or a function call."
                 }
             },
             "type": "object"
@@ -114,6 +199,9 @@
             "properties": {
                 "color": {
                     "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
@@ -162,6 +250,9 @@
                 "label": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -209,6 +300,9 @@
                 "opacity": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -216,6 +310,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -231,6 +328,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -249,6 +349,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -279,6 +382,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -298,6 +404,9 @@
                 "quantity": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -305,6 +414,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -320,6 +432,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -338,6 +453,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -370,6 +488,9 @@
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
                         },
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
                         },
                         {
@@ -386,15 +507,6 @@
                 }
             },
             "type": "object"
-        },
-        "ColorMapType": {
-            "description": "The Types that are allowed in a ColorMap.",
-            "enum": [
-                "intervals",
-                "ramp",
-                "values"
-            ],
-            "type": "string"
         },
         "CombinationFilter": {
             "additionalItems": {
@@ -418,14 +530,64 @@
             "description": "A ContrastEnhancement defines how the contrast of image data should be enhanced.",
             "properties": {
                 "enhancementType": {
-                    "enum": [
-                        "histogram",
-                        "normalize"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                        },
+                        {
+                            "enum": [
+                                "histogram",
+                                "normalize"
+                            ],
+                            "type": "string"
+                        }
                     ],
-                    "type": "string"
+                    "description": "Expressions can be a literal value, a property name or a function call."
                 },
                 "gammaValue": {
                     "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
@@ -434,6 +596,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -449,6 +614,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -467,6 +635,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -497,6 +668,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -524,6 +698,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -531,6 +708,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -546,6 +726,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -564,6 +747,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -594,6 +780,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -631,6 +820,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -638,6 +830,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -653,6 +848,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -671,6 +869,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -701,6 +902,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -730,6 +934,282 @@
             },
             "type": "object"
         },
+        "Fadd": {
+            "description": "Returns the sum of the arguments",
+            "properties": {
+                "args": {
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                            },
+                            {
+                                "type": "number"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "add"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Fall": {
+            "description": "Resolves to true if all passed arguments resolve to true",
+            "properties": {
+                "args": {
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fall"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fany"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FequalTo"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThan"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThanOrEqualTo"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThan"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThanOrEqualTo"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fnot"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FnotEqualTo"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEndsWith"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEqualsIgnoreCase"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrMatches"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStartsWith"
+                            },
+                            {
+                                "type": "boolean"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "all"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Fany": {
+            "description": "Resolves to true if any of the passed arguments resolves to true",
+            "properties": {
+                "args": {
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fall"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fany"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FequalTo"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThan"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThanOrEqualTo"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThan"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThanOrEqualTo"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fnot"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FnotEqualTo"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEndsWith"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEqualsIgnoreCase"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrMatches"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStartsWith"
+                            },
+                            {
+                                "type": "boolean"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "any"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "Fasin": {
             "description": "Returns the arc sine of an angle in radians, in the range of -PI / 2 through PI / 2",
             "properties": {
@@ -738,6 +1218,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -745,6 +1228,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -760,6 +1246,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -778,6 +1267,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -808,6 +1300,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -845,6 +1340,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -852,6 +1350,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -867,6 +1368,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -885,6 +1389,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -915,6 +1422,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -952,6 +1462,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -959,6 +1472,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -974,6 +1490,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -992,6 +1511,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -1022,6 +1544,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -1040,6 +1565,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -1047,6 +1575,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -1062,6 +1593,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -1080,6 +1614,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -1110,6 +1647,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -1147,6 +1687,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -1154,6 +1697,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -1169,6 +1715,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -1187,6 +1736,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -1217,6 +1769,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -1235,6 +1790,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -1242,6 +1800,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -1257,6 +1818,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -1275,6 +1839,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -1305,6 +1872,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -1323,6 +1893,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -1330,6 +1903,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -1345,6 +1921,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -1363,6 +1942,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -1393,6 +1975,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -1422,6 +2007,98 @@
             },
             "type": "object"
         },
+        "Fcase": {
+            "description": "Textual representation of a switch-case function.\nargument[0] - argument[args.length - 2] are objects with 'case' and\n'value'. argument[args.length -1] will be the default value.\n\nThe value of the first object where its 'case' Expression resolves to true\nwill be used.\nIf no 'case' expression resolves to true the default value will be returned.",
+            "properties": {
+                "args": {
+                    "additionalItems": {},
+                    "items": [
+                        {
+                            "properties": {
+                                "case": {
+                                    "anyOf": [
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fall"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fany"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FequalTo"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThan"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThanOrEqualTo"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThan"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThanOrEqualTo"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fnot"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnotEqualTo"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEndsWith"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEqualsIgnoreCase"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrMatches"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStartsWith"
+                                        },
+                                        {
+                                            "type": "boolean"
+                                        }
+                                    ],
+                                    "description": "Expressions can be a literal value, a property name or a function call."
+                                },
+                                "value": {
+                                    "description": "Expressions can be a literal value, a property name or a function call."
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ],
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "case"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "Fceil": {
             "description": "Returns the smallest (closest to negative infinity) number value that is greater than or equal to\nx and is equal to a mathematical integer.",
             "properties": {
@@ -1430,6 +2107,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -1437,6 +2117,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -1452,6 +2135,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -1470,6 +2156,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -1500,6 +2189,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -1537,6 +2229,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -1544,6 +2239,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -1559,6 +2257,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -1577,6 +2278,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -1607,6 +2311,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -1636,13 +2343,16 @@
             },
             "type": "object"
         },
-        "Fdouble2bool": {
-            "description": "Returns true if x is zero, false otherwise",
+        "Fdiv": {
+            "description": "Returns the division of argument[0] by argument[1]",
             "properties": {
                 "args": {
                     "items": [
                         {
                             "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
@@ -1651,6 +2361,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -1666,6 +2379,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -1684,6 +2400,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -1714,6 +2433,234 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 2,
+                    "minItems": 2,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "div"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Fdouble2bool": {
+            "description": "Returns true if x is zero, false otherwise",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -1743,6 +2690,27 @@
             },
             "type": "object"
         },
+        "FequalTo": {
+            "description": "Resolves to true if both arguments are equal",
+            "properties": {
+                "args": {
+                    "items": [
+                        {},
+                        {}
+                    ],
+                    "maxItems": 2,
+                    "minItems": 2,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "equalTo"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "Fexp": {
             "description": "Returns Euler’s number e raised to the power of x",
             "properties": {
@@ -1751,6 +2719,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -1758,6 +2729,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -1773,6 +2747,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -1791,6 +2768,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -1821,6 +2801,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -1858,6 +2841,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -1865,6 +2851,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -1880,6 +2869,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -1898,6 +2890,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -1930,6 +2925,9 @@
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
                                 },
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
                                 },
                                 {
@@ -1957,13 +2955,472 @@
             },
             "type": "object"
         },
+        "FgreaterThan": {
+            "description": "Resolves to true if argument[0] is greater than argument[1]",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 2,
+                    "minItems": 2,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "greaterThan"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "FgreaterThanOrEqualTo": {
+            "description": "Resolves to true if argument[0] is greater than or equal to argument[1]",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 2,
+                    "minItems": 2,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "greaterThanOrEqualTo"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "FillSymbolizer": {
             "description": "A FillSymbolizer describes the style representation of POLYGON data.",
             "properties": {
                 "antialias": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fall"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fany"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
@@ -1972,7 +3429,28 @@
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                         },
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FequalTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThanOrEqualTo"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThanOrEqualTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fnot"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnotEqualTo"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
@@ -1997,6 +3475,9 @@
                 },
                 "color": {
                     "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
@@ -2045,6 +3526,9 @@
                 "fillOpacity": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -2052,6 +3536,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -2067,6 +3554,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -2085,6 +3575,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -2115,6 +3608,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -2155,6 +3651,9 @@
                 "opacity": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -2162,6 +3661,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -2177,6 +3679,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -2195,6 +3700,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -2227,6 +3735,9 @@
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
                         },
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
                         },
                         {
@@ -2242,16 +3753,65 @@
                     "description": "Determines the total opacity for the Symbolizer.\nA value between 0 and 1. 0 is none opaque and 1 is full opaque."
                 },
                 "outlineCap": {
-                    "description": "The Captype for the outLine.",
-                    "enum": [
-                        "butt",
-                        "round",
-                        "square"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                        },
+                        {
+                            "enum": [
+                                "butt",
+                                "round",
+                                "square"
+                            ],
+                            "type": "string"
+                        }
                     ],
-                    "type": "string"
+                    "description": "The Captype for the outLine."
                 },
                 "outlineColor": {
                     "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
@@ -2302,6 +3862,9 @@
                     "items": {
                         "anyOf": [
                             {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                            },
+                            {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                             },
                             {
@@ -2309,6 +3872,9 @@
                             },
                             {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                             },
                             {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -2324,6 +3890,9 @@
                             },
                             {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                             },
                             {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -2342,6 +3911,9 @@
                             },
                             {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                             },
                             {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -2374,6 +3946,9 @@
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
                             },
                             {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
+                            },
+                            {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
                             },
                             {
@@ -2390,16 +3965,65 @@
                     "type": "array"
                 },
                 "outlineJoin": {
-                    "description": "The JoinType for the outLine.",
-                    "enum": [
-                        "bevel",
-                        "miter",
-                        "round"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                        },
+                        {
+                            "enum": [
+                                "bevel",
+                                "miter",
+                                "round"
+                            ],
+                            "type": "string"
+                        }
                     ],
-                    "type": "string"
+                    "description": "The JoinType for the outLine."
                 },
                 "outlineOpacity": {
                     "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
@@ -2408,6 +4032,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -2423,6 +4050,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -2441,6 +4071,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -2471,6 +4104,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -2490,6 +4126,9 @@
                 "outlineWidth": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -2497,6 +4136,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -2512,6 +4154,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -2530,6 +4175,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -2560,6 +4208,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -2587,7 +4238,16 @@
                 "visibility": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fall"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fany"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
@@ -2596,7 +4256,28 @@
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                         },
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FequalTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThanOrEqualTo"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThanOrEqualTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fnot"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnotEqualTo"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
@@ -2625,6 +4306,63 @@
         "Filter": {
             "anyOf": [
                 {
+                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                },
+                {
+                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                },
+                {
+                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fall"
+                },
+                {
+                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fany"
+                },
+                {
+                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
+                },
+                {
+                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
+                },
+                {
+                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FequalTo"
+                },
+                {
+                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThan"
+                },
+                {
+                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThanOrEqualTo"
+                },
+                {
+                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                },
+                {
+                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThan"
+                },
+                {
+                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThanOrEqualTo"
+                },
+                {
+                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fnot"
+                },
+                {
+                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnotEqualTo"
+                },
+                {
+                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
+                },
+                {
+                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEndsWith"
+                },
+                {
+                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEqualsIgnoreCase"
+                },
+                {
+                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrMatches"
+                },
+                {
+                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStartsWith"
+                },
+                {
                     "description": "A Filter that checks if a property is in a range of two values (inclusive).",
                     "items": [
                         {
@@ -2635,6 +4373,9 @@
                         },
                         {
                             "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
@@ -2682,6 +4423,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -2689,6 +4433,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -2704,6 +4451,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -2722,6 +4472,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -2752,6 +4505,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -2770,6 +4526,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -2777,6 +4536,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -2792,6 +4554,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -2810,6 +4575,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -2840,6 +4608,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -2879,6 +4650,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -2886,6 +4660,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -2901,6 +4678,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -2919,6 +4699,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -2949,6 +4732,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -2996,13 +4782,40 @@
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
                                 },
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fall"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fany"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                                 },
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FequalTo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThanOrEqualTo"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThanOrEqualTo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fnot"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnotEqualTo"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
@@ -3032,6 +4845,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -3039,6 +4855,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -3054,6 +4873,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -3072,6 +4894,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -3102,6 +4927,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -3149,13 +4977,40 @@
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
                                 },
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fall"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fany"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                                 },
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FequalTo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThanOrEqualTo"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThanOrEqualTo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fnot"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnotEqualTo"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
@@ -3207,6 +5062,9 @@
                     "maxItems": 2,
                     "minItems": 2,
                     "type": "array"
+                },
+                {
+                    "type": "boolean"
                 }
             ]
         },
@@ -3216,6 +5074,9 @@
                 "args": {
                     "items": {
                         "anyOf": [
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                            },
                             {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                             },
@@ -3271,13 +5132,16 @@
             },
             "type": "object"
         },
-        "Flog": {
-            "description": "Returns the natural logarithm (base e) of x",
+        "FlessThan": {
+            "description": "Resolves to true if argument[0] is less than argument[1]",
             "properties": {
                 "args": {
                     "items": [
                         {
                             "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
@@ -3286,6 +5150,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -3301,6 +5168,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -3319,6 +5189,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -3349,6 +5222,459 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 2,
+                    "minItems": 2,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "lessThan"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "FlessThanOrEqualTo": {
+            "description": "Resolves to true if argument[0] is less than or equal to argument[1]",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 2,
+                    "minItems": 2,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "lessThanOrEqualTo"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Flog": {
+            "description": "Returns the natural logarithm (base e) of x",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -3385,6 +5711,9 @@
                     "items": {
                         "anyOf": [
                             {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                            },
+                            {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                             },
                             {
@@ -3392,6 +5721,9 @@
                             },
                             {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                             },
                             {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -3407,6 +5739,9 @@
                             },
                             {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                             },
                             {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -3425,6 +5760,9 @@
                             },
                             {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                             },
                             {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -3455,6 +5793,9 @@
                             },
                             {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                             },
                             {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -3488,6 +5829,9 @@
                     "items": {
                         "anyOf": [
                             {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                            },
+                            {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                             },
                             {
@@ -3495,6 +5839,9 @@
                             },
                             {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                             },
                             {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -3510,6 +5857,9 @@
                             },
                             {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                             },
                             {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -3528,6 +5878,9 @@
                             },
                             {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                             },
                             {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -3560,6 +5913,9 @@
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
                             },
                             {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
+                            },
+                            {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
                             },
                             {
@@ -3585,11 +5941,15 @@
             "type": "object"
         },
         "Fmodulo": {
+            "description": "Returns the remainder after integer division of argument[0] by argument[1]",
             "properties": {
                 "args": {
                     "items": [
                         {
                             "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
@@ -3598,6 +5958,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -3613,6 +5976,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -3631,6 +5997,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -3661,6 +6030,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -3679,6 +6051,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -3686,6 +6061,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -3701,6 +6079,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -3719,6 +6100,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -3749,6 +6133,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -3778,6 +6165,228 @@
             },
             "type": "object"
         },
+        "Fmul": {
+            "description": "Returns the product of the arguments",
+            "properties": {
+                "args": {
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                            },
+                            {
+                                "type": "number"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "mul"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Fnot": {
+            "description": "Inverts the boolean value of argument[0]",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fall"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fany"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FequalTo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThanOrEqualTo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThanOrEqualTo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fnot"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnotEqualTo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEndsWith"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEqualsIgnoreCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrMatches"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStartsWith"
+                                },
+                                {
+                                    "type": "boolean"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 1,
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "not"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "FnotEqualTo": {
+            "description": "Resolves to false if both arguments are equal",
+            "properties": {
+                "args": {
+                    "items": [
+                        {},
+                        {}
+                    ],
+                    "maxItems": 2,
+                    "minItems": 2,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "notEqualTo"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "FnumberFormat": {
             "description": "Formats the number (argument[1]) according to the specified format (arguments[0]) using the default locale\nor the one provided (argument[2]) as an optional argument. The format syntax can be found\nin the Java DecimalFormat javadocs",
             "properties": {
@@ -3785,6 +6394,9 @@
                     "items": [
                         {
                             "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
@@ -3832,6 +6444,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -3839,6 +6454,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -3854,6 +6472,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -3872,6 +6493,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -3904,6 +6528,9 @@
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
                                 },
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
                                 },
                                 {
@@ -3919,6 +6546,9 @@
                         },
                         {
                             "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
@@ -3984,6 +6614,9 @@
                     "items": [
                         {
                             "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
@@ -4062,6 +6695,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -4069,6 +6705,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -4084,6 +6723,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -4102,6 +6744,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -4132,6 +6777,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -4150,6 +6798,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -4157,6 +6808,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -4172,6 +6826,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -4190,6 +6847,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -4220,6 +6880,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -4256,6 +6919,9 @@
                     "items": [
                         {
                             "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
@@ -4334,6 +7000,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -4341,6 +7010,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -4356,6 +7028,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -4374,6 +7049,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -4404,6 +7082,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -4441,6 +7122,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -4448,6 +7132,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -4463,6 +7150,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -4481,6 +7171,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -4511,6 +7204,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -4548,6 +7244,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -4555,6 +7254,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -4570,6 +7272,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -4588,6 +7293,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -4618,6 +7326,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -4655,6 +7366,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -4662,6 +7376,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -4677,6 +7394,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -4695,6 +7415,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -4725,6 +7448,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -4761,6 +7487,9 @@
                     "items": [
                         {
                             "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
@@ -4808,6 +7537,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -4815,6 +7547,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -4830,6 +7565,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -4848,6 +7586,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -4880,6 +7621,9 @@
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
                                 },
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
                                 },
                                 {
@@ -4896,6 +7640,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -4903,6 +7650,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -4918,6 +7668,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -4936,6 +7689,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -4968,6 +7724,9 @@
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
                                 },
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
                                 },
                                 {
@@ -4983,6 +7742,9 @@
                         },
                         {
                             "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
@@ -5049,6 +7811,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -5113,6 +7878,9 @@
                     "items": {
                         "anyOf": [
                             {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                            },
+                            {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                             },
                             {
@@ -5175,6 +7943,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -5220,6 +7991,9 @@
                         },
                         {
                             "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
@@ -5286,6 +8060,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -5331,6 +8108,9 @@
                         },
                         {
                             "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
@@ -5397,6 +8177,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -5442,6 +8225,9 @@
                         },
                         {
                             "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
@@ -5508,6 +8294,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -5553,6 +8342,9 @@
                         },
                         {
                             "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
@@ -5619,6 +8411,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -5664,6 +8459,9 @@
                         },
                         {
                             "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
@@ -5730,6 +8528,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -5795,6 +8596,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -5840,6 +8644,9 @@
                         },
                         {
                             "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
@@ -5906,97 +8713,8 @@
                         {
                             "anyOf": [
                                 {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
                                 },
-                                {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
-                                },
-                                {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
-                                },
-                                {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
-                                },
-                                {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
-                                },
-                                {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
-                                },
-                                {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
-                                },
-                                {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
-                                },
-                                {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
-                                },
-                                {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
-                                },
-                                {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
-                                },
-                                {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
-                                },
-                                {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
-                                },
-                                {
-                                    "type": "string"
-                                }
-                            ]
-                        },
-                        {
-                            "anyOf": [
-                                {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
-                                },
-                                {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
-                                },
-                                {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
-                                },
-                                {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
-                                },
-                                {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
-                                },
-                                {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
-                                },
-                                {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
-                                },
-                                {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
-                                },
-                                {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
-                                },
-                                {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
-                                },
-                                {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
-                                },
-                                {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
-                                },
-                                {
-                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
-                                },
-                                {
-                                    "type": "string"
-                                }
-                            ]
-                        },
-                        {
-                            "anyOf": [
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
@@ -6044,7 +8762,114 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fall"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fany"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
@@ -6053,7 +8878,28 @@
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                                 },
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FequalTo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThanOrEqualTo"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThanOrEqualTo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fnot"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FnotEqualTo"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
@@ -6097,6 +8943,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -6142,6 +8991,9 @@
                         },
                         {
                             "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
@@ -6208,6 +9060,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -6273,6 +9128,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -6319,6 +9177,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -6326,6 +9187,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -6341,6 +9205,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -6359,6 +9226,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -6389,6 +9259,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -6407,6 +9280,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -6414,6 +9290,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -6429,6 +9308,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -6447,6 +9329,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -6477,6 +9362,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -6514,6 +9402,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -6560,6 +9451,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -6567,6 +9461,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -6582,6 +9479,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -6600,6 +9500,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -6630,6 +9533,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -6666,6 +9572,9 @@
                     "items": [
                         {
                             "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
@@ -6732,6 +9641,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -6797,6 +9709,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -6854,13 +9769,16 @@
             },
             "type": "object"
         },
-        "Ftan": {
-            "description": "Returns the trigonometric tangent of angle expressed in radians",
+        "Fsub": {
+            "description": "Returns the result of substracting argument[1] from argument[0]",
             "properties": {
                 "args": {
                     "items": [
                         {
                             "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
@@ -6869,6 +9787,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -6884,6 +9805,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -6902,6 +9826,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -6932,6 +9859,234 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoDegrees"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FtoRadians"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        }
+                    ],
+                    "maxItems": 2,
+                    "minItems": 2,
+                    "type": "array"
+                },
+                "name": {
+                    "enum": [
+                        "sub"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Ftan": {
+            "description": "Returns the trigonometric tangent of angle expressed in radians",
+            "properties": {
+                "args": {
+                    "items": [
+                        {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fabs"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fatan2"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fceil"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Ffloor"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Flog"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmax"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpow"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frandom"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Frint"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fround"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsin"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsqrt"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLastIndexOf"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -6969,6 +10124,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -6976,6 +10134,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -6991,6 +10152,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -7009,6 +10173,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -7039,6 +10206,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -7076,6 +10246,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -7083,6 +10256,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -7098,6 +10274,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -7116,6 +10295,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -7146,6 +10328,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -7190,7 +10375,16 @@
                 "allowOverlap": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fall"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fany"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
@@ -7199,7 +10393,28 @@
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                         },
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FequalTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThanOrEqualTo"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThanOrEqualTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fnot"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnotEqualTo"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
@@ -7223,24 +10438,79 @@
                     "description": "If true, the icon will be visible even if it collides with other previously\ndrawn symbols."
                 },
                 "anchor": {
-                    "description": "Part of the icon placed closest to the anchor. This may conflict with a set\noffset.",
-                    "enum": [
-                        "bottom",
-                        "bottom-left",
-                        "bottom-right",
-                        "center",
-                        "left",
-                        "right",
-                        "top",
-                        "top-left",
-                        "top-right"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                        },
+                        {
+                            "enum": [
+                                "bottom",
+                                "bottom-left",
+                                "bottom-right",
+                                "center",
+                                "left",
+                                "right",
+                                "top",
+                                "top-left",
+                                "top-right"
+                            ],
+                            "type": "string"
+                        }
                     ],
-                    "type": "string"
+                    "description": "Part of the icon placed closest to the anchor. This may conflict with a set\noffset."
                 },
                 "avoidEdges": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fall"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fany"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
@@ -7249,7 +10519,28 @@
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                         },
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FequalTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThanOrEqualTo"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThanOrEqualTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fnot"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnotEqualTo"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
@@ -7274,6 +10565,9 @@
                 },
                 "color": {
                     "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
@@ -7320,18 +10614,67 @@
                     "description": "A color defined as a hex-color string."
                 },
                 "format": {
-                    "description": "An optional configuration for the image format as MIME type.\nThis might be needed if the image(path) has no filending specified. e.g. http://myserver/getImage",
-                    "enum": [
-                        "image/gif",
-                        "image/jpeg",
-                        "image/jpg",
-                        "image/png",
-                        "image/svg+xml"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                        },
+                        {
+                            "enum": [
+                                "image/gif",
+                                "image/jpeg",
+                                "image/jpg",
+                                "image/png",
+                                "image/svg+xml"
+                            ],
+                            "type": "string"
+                        }
                     ],
-                    "type": "string"
+                    "description": "An optional configuration for the image format as MIME type.\nThis might be needed if the image(path) has no filending specified. e.g. http://myserver/getImage"
                 },
                 "haloBlur": {
                     "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
@@ -7340,6 +10683,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -7355,6 +10701,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -7373,6 +10722,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -7405,6 +10757,9 @@
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
                         },
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
                         },
                         {
@@ -7421,6 +10776,9 @@
                 },
                 "haloColor": {
                     "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
@@ -7469,6 +10827,9 @@
                 "haloOpacity": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -7476,6 +10837,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -7491,6 +10855,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -7509,6 +10876,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -7539,6 +10909,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -7558,6 +10931,9 @@
                 "haloWidth": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -7565,6 +10941,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -7580,6 +10959,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -7598,6 +10980,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -7628,6 +11013,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -7654,6 +11042,9 @@
                 },
                 "image": {
                     "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
@@ -7702,7 +11093,16 @@
                 "keepUpright": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fall"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fany"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
@@ -7711,7 +11111,28 @@
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                         },
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FequalTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThanOrEqualTo"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThanOrEqualTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fnot"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnotEqualTo"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
@@ -7747,6 +11168,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -7754,6 +11178,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -7769,6 +11196,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -7787,6 +11217,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -7817,6 +11250,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -7835,6 +11271,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -7842,6 +11281,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -7857,6 +11299,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -7875,6 +11320,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -7905,6 +11353,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -7926,15 +11377,64 @@
                     "type": "array"
                 },
                 "offsetAnchor": {
-                    "description": "Property relevant for mapbox-styles.\nCompare https://docs.mapbox.com/mapbox-gl-js/style-spec/#paint-symbol-icon-translate-anchor",
-                    "enum": [
-                        "map",
-                        "viewport"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                        },
+                        {
+                            "enum": [
+                                "map",
+                                "viewport"
+                            ],
+                            "type": "string"
+                        }
                     ],
-                    "type": "string"
+                    "description": "Property relevant for mapbox-styles.\nCompare https://docs.mapbox.com/mapbox-gl-js/style-spec/#paint-symbol-icon-translate-anchor"
                 },
                 "opacity": {
                     "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
@@ -7943,6 +11443,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -7958,6 +11461,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -7976,6 +11482,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -8008,6 +11517,9 @@
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
                         },
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
                         },
                         {
@@ -8025,7 +11537,16 @@
                 "optional": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fall"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fany"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
@@ -8034,7 +11555,28 @@
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                         },
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FequalTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThanOrEqualTo"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThanOrEqualTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fnot"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnotEqualTo"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
@@ -8060,6 +11602,9 @@
                 "padding": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -8067,6 +11612,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -8082,6 +11630,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -8100,6 +11651,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -8130,6 +11684,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -8147,16 +11704,65 @@
                     "description": "Size of the additional area around the icon used for detecting symbol collisions."
                 },
                 "pitchAlignment": {
-                    "description": "Property relevant for mapbox-styles.\nCompare https://docs.mapbox.com/mapbox-gl-js/style-spec/#layout-symbol-icon-pitch-alignment",
-                    "enum": [
-                        "auto",
-                        "map",
-                        "viewport"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                        },
+                        {
+                            "enum": [
+                                "auto",
+                                "map",
+                                "viewport"
+                            ],
+                            "type": "string"
+                        }
                     ],
-                    "type": "string"
+                    "description": "Property relevant for mapbox-styles.\nCompare https://docs.mapbox.com/mapbox-gl-js/style-spec/#layout-symbol-icon-pitch-alignment"
                 },
                 "rotate": {
                     "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
@@ -8165,6 +11771,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -8180,6 +11789,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -8198,6 +11810,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -8228,6 +11843,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -8245,16 +11863,65 @@
                     "description": "The rotation of the Symbolizer in degrees. Value should be between 0 and 360."
                 },
                 "rotationAlignment": {
-                    "description": "Property relevant for mapbox-styles.\nCompare https://docs.mapbox.com/mapbox-gl-js/style-spec/#layout-symbol-icon-rotation-alignment",
-                    "enum": [
-                        "auto",
-                        "map",
-                        "viewport"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                        },
+                        {
+                            "enum": [
+                                "auto",
+                                "map",
+                                "viewport"
+                            ],
+                            "type": "string"
+                        }
                     ],
-                    "type": "string"
+                    "description": "Property relevant for mapbox-styles.\nCompare https://docs.mapbox.com/mapbox-gl-js/style-spec/#layout-symbol-icon-rotation-alignment"
                 },
                 "size": {
                     "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
@@ -8263,6 +11930,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -8278,6 +11948,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -8296,6 +11969,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -8326,6 +12002,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -8351,14 +12030,60 @@
                     "type": "string"
                 },
                 "textFit": {
-                    "description": "Property relevant for mapbox-styles.\nCompare https://docs.mapbox.com/mapbox-gl-js/style-spec/#layout-symbol-icon-text-fit",
-                    "enum": [
-                        "both",
-                        "height",
-                        "none",
-                        "width"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                        },
+                        {
+                            "enum": [
+                                "both",
+                                "height",
+                                "none",
+                                "width"
+                            ],
+                            "type": "string"
+                        }
                     ],
-                    "type": "string"
+                    "description": "Property relevant for mapbox-styles.\nCompare https://docs.mapbox.com/mapbox-gl-js/style-spec/#layout-symbol-icon-text-fit"
                 },
                 "textFitPadding": {
                     "description": "Property relevant for mapbox-styles.\nCompare https://docs.mapbox.com/mapbox-gl-js/style-spec/#layout-symbol-icon-text-fit-padding",
@@ -8366,6 +12091,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -8373,6 +12101,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -8388,6 +12119,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -8406,6 +12140,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -8436,6 +12173,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -8454,6 +12194,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -8461,6 +12204,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -8476,6 +12222,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -8494,6 +12243,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -8524,6 +12276,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -8542,6 +12297,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -8549,6 +12307,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -8564,6 +12325,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -8582,6 +12346,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -8612,6 +12379,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -8630,6 +12400,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -8637,6 +12410,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -8652,6 +12428,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -8670,6 +12449,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -8700,6 +12482,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -8723,7 +12508,16 @@
                 "visibility": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fall"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fany"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
@@ -8732,7 +12526,28 @@
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                         },
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FequalTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThanOrEqualTo"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThanOrEqualTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fnot"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnotEqualTo"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
@@ -8764,6 +12579,9 @@
                 "blur": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -8771,6 +12589,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -8786,6 +12607,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -8804,6 +12628,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -8836,6 +12663,9 @@
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
                         },
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
                         },
                         {
@@ -8851,16 +12681,65 @@
                     "description": "Expressions can be a literal value, a property name or a function call."
                 },
                 "cap": {
-                    "description": "The Captype for the LineSymbolizer.",
-                    "enum": [
-                        "butt",
-                        "round",
-                        "square"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                        },
+                        {
+                            "enum": [
+                                "butt",
+                                "round",
+                                "square"
+                            ],
+                            "type": "string"
+                        }
                     ],
-                    "type": "string"
+                    "description": "The Captype for the LineSymbolizer."
                 },
                 "color": {
                     "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
@@ -8909,6 +12788,9 @@
                 "dashOffset": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -8916,6 +12798,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -8931,6 +12816,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -8949,6 +12837,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -8981,6 +12872,9 @@
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
                         },
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
                         },
                         {
@@ -9000,6 +12894,9 @@
                     "items": {
                         "anyOf": [
                             {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                            },
+                            {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                             },
                             {
@@ -9007,6 +12904,9 @@
                             },
                             {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                             },
                             {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -9022,6 +12922,9 @@
                             },
                             {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                             },
                             {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -9040,6 +12943,9 @@
                             },
                             {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                            },
+                            {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                             },
                             {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -9072,6 +12978,9 @@
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
                             },
                             {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
+                            },
+                            {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
                             },
                             {
@@ -9090,6 +12999,9 @@
                 "gapWidth": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -9097,6 +13009,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -9112,6 +13027,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -9130,6 +13048,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -9160,6 +13081,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -9218,13 +13142,59 @@
                     "description": "Renders the line with a repeated linear PointSymbolizer."
                 },
                 "join": {
-                    "description": "The JoinType for the LineSymbolizer.",
-                    "enum": [
-                        "bevel",
-                        "miter",
-                        "round"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                        },
+                        {
+                            "enum": [
+                                "bevel",
+                                "miter",
+                                "round"
+                            ],
+                            "type": "string"
+                        }
                     ],
-                    "type": "string"
+                    "description": "The JoinType for the LineSymbolizer."
                 },
                 "kind": {
                     "description": "Describes the type of the kind of the Symbolizer.",
@@ -9236,6 +13206,9 @@
                 "miterLimit": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -9243,6 +13216,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -9258,6 +13234,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -9276,6 +13255,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -9306,6 +13288,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -9325,6 +13310,9 @@
                 "opacity": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -9332,6 +13320,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -9347,6 +13338,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -9365,6 +13359,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -9395,6 +13392,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -9414,6 +13414,9 @@
                 "perpendicularOffset": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -9421,6 +13424,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -9436,6 +13442,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -9454,6 +13463,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -9484,6 +13496,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -9503,6 +13518,9 @@
                 "roundLimit": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -9510,6 +13528,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -9525,6 +13546,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -9543,6 +13567,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -9573,6 +13600,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -9592,6 +13622,9 @@
                 "spacing": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -9599,6 +13632,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -9614,6 +13650,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -9632,6 +13671,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -9662,6 +13704,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -9690,7 +13735,16 @@
                 "visibility": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fall"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fany"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
@@ -9699,7 +13753,28 @@
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                         },
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FequalTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThanOrEqualTo"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThanOrEqualTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fnot"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnotEqualTo"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
@@ -9725,6 +13800,9 @@
                 "width": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -9732,6 +13810,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -9747,6 +13828,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -9765,6 +13849,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -9795,6 +13882,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -9828,7 +13918,16 @@
                 "avoidEdges": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fall"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fany"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
@@ -9837,7 +13936,28 @@
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                         },
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FequalTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThanOrEqualTo"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThanOrEqualTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fnot"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnotEqualTo"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
@@ -9863,6 +13983,9 @@
                 "blur": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -9870,6 +13993,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -9885,6 +14011,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -9903,6 +14032,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -9935,6 +14067,9 @@
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
                         },
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
                         },
                         {
@@ -9951,6 +14086,9 @@
                 },
                 "color": {
                     "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
@@ -9999,6 +14137,9 @@
                 "fillOpacity": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -10006,6 +14147,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -10021,6 +14165,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -10039,6 +14186,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -10069,6 +14219,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -10098,6 +14251,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -10105,6 +14261,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -10120,6 +14279,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -10138,6 +14300,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -10168,6 +14333,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -10186,6 +14354,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -10193,6 +14364,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -10208,6 +14382,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -10226,6 +14403,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -10256,6 +14436,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -10277,15 +14460,64 @@
                     "type": "array"
                 },
                 "offsetAnchor": {
-                    "description": "Property relevant for mapbox-styles.\nCompare https://docs.mapbox.com/mapbox-gl-js/style-spec/#paint-symbol-icon-translate-anchor",
-                    "enum": [
-                        "map",
-                        "viewport"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                        },
+                        {
+                            "enum": [
+                                "map",
+                                "viewport"
+                            ],
+                            "type": "string"
+                        }
                     ],
-                    "type": "string"
+                    "description": "Property relevant for mapbox-styles.\nCompare https://docs.mapbox.com/mapbox-gl-js/style-spec/#paint-symbol-icon-translate-anchor"
                 },
                 "opacity": {
                     "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
@@ -10294,6 +14526,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -10309,6 +14544,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -10327,6 +14565,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -10357,6 +14598,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -10374,23 +14618,118 @@
                     "description": "Determines the total opacity for the Symbolizer.\nA value between 0 and 1. 0 is none opaque and 1 is full opaque."
                 },
                 "pitchAlignment": {
-                    "description": "Property relevant for mapbox-styles.\nCompare https://docs.mapbox.com/mapbox-gl-js/style-spec/#paint-circle-circle-pitch-alignment",
-                    "enum": [
-                        "map",
-                        "viewport"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                        },
+                        {
+                            "enum": [
+                                "map",
+                                "viewport"
+                            ],
+                            "type": "string"
+                        }
                     ],
-                    "type": "string"
+                    "description": "Property relevant for mapbox-styles.\nCompare https://docs.mapbox.com/mapbox-gl-js/style-spec/#paint-circle-circle-pitch-alignment"
                 },
                 "pitchScale": {
-                    "description": "Property relevant for mapbox-styles.\nCompare https://docs.mapbox.com/mapbox-gl-js/style-spec/#paint-circle-circle-pitch-scale",
-                    "enum": [
-                        "map",
-                        "viewport"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                        },
+                        {
+                            "enum": [
+                                "map",
+                                "viewport"
+                            ],
+                            "type": "string"
+                        }
                     ],
-                    "type": "string"
+                    "description": "Property relevant for mapbox-styles.\nCompare https://docs.mapbox.com/mapbox-gl-js/style-spec/#paint-circle-circle-pitch-scale"
                 },
                 "radius": {
                     "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
@@ -10399,6 +14738,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -10414,6 +14756,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -10432,6 +14777,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -10462,6 +14810,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -10489,6 +14840,9 @@
                 "rotate": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -10496,6 +14850,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -10511,6 +14868,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -10529,6 +14889,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -10561,6 +14924,9 @@
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
                         },
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
                         },
                         {
@@ -10577,6 +14943,9 @@
                 },
                 "strokeColor": {
                     "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
@@ -10625,6 +14994,9 @@
                 "strokeOpacity": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -10632,6 +15004,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -10647,6 +15022,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -10665,6 +15043,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -10695,6 +15076,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -10714,6 +15098,9 @@
                 "strokeWidth": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -10721,6 +15108,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -10736,6 +15126,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -10754,6 +15147,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -10784,6 +15180,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -10811,7 +15210,16 @@
                 "visibility": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fall"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fany"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
@@ -10820,7 +15228,28 @@
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                         },
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FequalTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThanOrEqualTo"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThanOrEqualTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fnot"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnotEqualTo"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
@@ -10915,6 +15344,9 @@
                 "brightnessMax": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -10922,6 +15354,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -10937,6 +15372,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -10955,6 +15393,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -10985,6 +15426,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -11004,6 +15448,9 @@
                 "brightnessMin": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -11011,6 +15458,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -11026,6 +15476,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -11044,6 +15497,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -11074,6 +15530,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -11098,14 +15557,18 @@
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/GrayChannel"
                         }
-                    ]
+                    ],
+                    "description": "Specifies how dataset bands are mapped to image color channels."
                 },
                 "colorMap": {
                     "$ref": "http://geostyler/geostyler-style.json#/definitions/ColorMap",
-                    "description": "A ColorMap defines the color values for the pixels of a raster image."
+                    "description": "Defines the color values for the pixels of a raster image,\nas either color gradients, or a mapping of specific values to fixed colors."
                 },
                 "contrast": {
                     "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
@@ -11114,6 +15577,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -11129,6 +15595,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -11147,6 +15616,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -11177,6 +15649,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -11195,10 +15670,13 @@
                 },
                 "contrastEnhancement": {
                     "$ref": "http://geostyler/geostyler-style.json#/definitions/ContrastEnhancement",
-                    "description": "A ContrastEnhancement defines how the contrast of image data should be enhanced."
+                    "description": "Can be used to adjust the relative brightness of the image data."
                 },
                 "fadeDuration": {
                     "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
@@ -11207,6 +15685,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -11222,6 +15703,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -11240,6 +15724,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -11270,6 +15757,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -11289,6 +15779,9 @@
                 "hueRotate": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -11296,6 +15789,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -11311,6 +15807,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -11329,6 +15828,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -11359,6 +15861,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -11384,6 +15889,9 @@
                 "opacity": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -11391,6 +15899,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -11406,6 +15917,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -11424,6 +15938,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -11454,6 +15971,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -11468,17 +15988,67 @@
                             "type": "number"
                         }
                     ],
-                    "description": "Expressions can be a literal value, a property name or a function call."
+                    "description": "Determines the total opacity for the Symbolizer.\nA value between 0 and 1. 0 is none opaque and 1 is fully opaque."
                 },
                 "resampling": {
-                    "enum": [
-                        "linear",
-                        "nearest"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                        },
+                        {
+                            "enum": [
+                                "linear",
+                                "nearest"
+                            ],
+                            "type": "string"
+                        }
                     ],
-                    "type": "string"
+                    "description": "Expressions can be a literal value, a property name or a function call."
                 },
                 "saturation": {
                     "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
@@ -11487,6 +16057,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -11502,6 +16075,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -11520,6 +16096,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -11550,6 +16129,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -11569,7 +16151,16 @@
                 "visibility": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fall"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fany"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
@@ -11578,7 +16169,28 @@
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                         },
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FequalTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThanOrEqualTo"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThanOrEqualTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fnot"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnotEqualTo"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
@@ -11599,7 +16211,7 @@
                             "type": "boolean"
                         }
                     ],
-                    "description": "Expressions can be a literal value, a property name or a function call."
+                    "description": "Defines whether the Symbolizer should be visible or not."
                 }
             },
             "type": "object"
@@ -11609,6 +16221,63 @@
             "properties": {
                 "filter": {
                     "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fall"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fany"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FequalTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThanOrEqualTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThanOrEqualTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fnot"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnotEqualTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEndsWith"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrEqualsIgnoreCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrMatches"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStartsWith"
+                        },
                         {
                             "description": "A Filter that checks if a property is in a range of two values (inclusive).",
                             "items": [
@@ -11620,6 +16289,9 @@
                                 },
                                 {
                                     "anyOf": [
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                        },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                         },
@@ -11667,6 +16339,9 @@
                                 {
                                     "anyOf": [
                                         {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                        },
+                                        {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                         },
                                         {
@@ -11674,6 +16349,9 @@
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -11689,6 +16367,9 @@
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -11707,6 +16388,9 @@
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -11737,6 +16421,9 @@
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -11755,6 +16442,9 @@
                                 {
                                     "anyOf": [
                                         {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                        },
+                                        {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                         },
                                         {
@@ -11762,6 +16452,9 @@
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -11777,6 +16470,9 @@
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -11795,6 +16491,9 @@
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -11825,6 +16524,9 @@
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -11864,6 +16566,9 @@
                                 {
                                     "anyOf": [
                                         {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                        },
+                                        {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                         },
                                         {
@@ -11871,6 +16576,9 @@
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -11886,6 +16594,9 @@
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -11904,6 +16615,9 @@
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -11934,6 +16648,9 @@
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -11981,13 +16698,40 @@
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
                                         },
                                         {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fall"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fany"
+                                        },
+                                        {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                                         },
                                         {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FequalTo"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThan"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThanOrEqualTo"
+                                        },
+                                        {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThan"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThanOrEqualTo"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fnot"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnotEqualTo"
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
@@ -12017,6 +16761,9 @@
                                 {
                                     "anyOf": [
                                         {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                        },
+                                        {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                         },
                                         {
@@ -12024,6 +16771,9 @@
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -12039,6 +16789,9 @@
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -12057,6 +16810,9 @@
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -12087,6 +16843,9 @@
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -12134,13 +16893,40 @@
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
                                         },
                                         {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fall"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fany"
+                                        },
+                                        {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                                         },
                                         {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FequalTo"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThan"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThanOrEqualTo"
+                                        },
+                                        {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThan"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThanOrEqualTo"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fnot"
+                                        },
+                                        {
+                                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnotEqualTo"
                                         },
                                         {
                                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
@@ -12179,6 +16965,9 @@
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/NegationFilter",
                             "description": "A NegationFilter negates a given Filter."
+                        },
+                        {
+                            "type": "boolean"
                         }
                     ]
                 },
@@ -12224,6 +17013,9 @@
                 "max": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -12231,6 +17023,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -12246,6 +17041,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -12264,6 +17062,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -12294,6 +17095,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -12313,6 +17117,9 @@
                 "min": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -12320,6 +17127,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -12335,6 +17145,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -12353,6 +17166,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -12383,6 +17199,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -12408,7 +17227,16 @@
                 "allowOverlap": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fall"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fany"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
@@ -12417,7 +17245,28 @@
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                         },
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FequalTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThanOrEqualTo"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThanOrEqualTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fnot"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnotEqualTo"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
@@ -12441,24 +17290,79 @@
                     "description": "If true, the text will be visible even if it collides with other previously\ndrawn symbols."
                 },
                 "anchor": {
-                    "description": "The anchor position of the label referred to the center of the geometry.",
-                    "enum": [
-                        "bottom",
-                        "bottom-left",
-                        "bottom-right",
-                        "center",
-                        "left",
-                        "right",
-                        "top",
-                        "top-left",
-                        "top-right"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                        },
+                        {
+                            "enum": [
+                                "bottom",
+                                "bottom-left",
+                                "bottom-right",
+                                "center",
+                                "left",
+                                "right",
+                                "top",
+                                "top-left",
+                                "top-right"
+                            ],
+                            "type": "string"
+                        }
                     ],
-                    "type": "string"
+                    "description": "The anchor position of the label referred to the center of the geometry."
                 },
                 "avoidEdges": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fall"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fany"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
@@ -12467,7 +17371,28 @@
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                         },
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FequalTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThanOrEqualTo"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThanOrEqualTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fnot"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnotEqualTo"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
@@ -12492,6 +17417,9 @@
                 },
                 "color": {
                     "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
@@ -12542,6 +17470,9 @@
                     "items": {
                         "anyOf": [
                             {
+                                "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                            },
+                            {
                                 "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                             },
                             {
@@ -12588,24 +17519,119 @@
                     "type": "array"
                 },
                 "fontStyle": {
-                    "description": "Specifies whether a font should be styled with a normal, italic, or oblique\nface from its font-family.",
-                    "enum": [
-                        "italic",
-                        "normal",
-                        "oblique"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                        },
+                        {
+                            "enum": [
+                                "italic",
+                                "normal",
+                                "oblique"
+                            ],
+                            "type": "string"
+                        }
                     ],
-                    "type": "string"
+                    "description": "Specifies whether a font should be styled with a normal, italic, or oblique\nface from its font-family."
                 },
                 "fontWeight": {
-                    "description": "Specifies the weight (or boldness) of the font. The weights available depend\non the font-family you are using.",
-                    "enum": [
-                        "bold",
-                        "normal"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                        },
+                        {
+                            "enum": [
+                                "bold",
+                                "normal"
+                            ],
+                            "type": "string"
+                        }
                     ],
-                    "type": "string"
+                    "description": "Specifies the weight (or boldness) of the font. The weights available depend\non the font-family you are using."
                 },
                 "haloBlur": {
                     "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
@@ -12614,6 +17640,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -12629,6 +17658,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -12647,6 +17679,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -12679,6 +17714,9 @@
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
                         },
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
                         },
                         {
@@ -12695,6 +17733,9 @@
                 },
                 "haloColor": {
                     "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
@@ -12743,6 +17784,9 @@
                 "haloOpacity": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -12750,6 +17794,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -12765,6 +17812,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -12783,6 +17833,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -12813,6 +17866,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -12832,6 +17888,9 @@
                 "haloWidth": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -12839,6 +17898,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -12854,6 +17916,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -12872,6 +17937,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -12902,6 +17970,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -12927,18 +17998,73 @@
                     "type": "string"
                 },
                 "justify": {
-                    "description": "Text justification option to align the text.",
-                    "enum": [
-                        "center",
-                        "left",
-                        "right"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                        },
+                        {
+                            "enum": [
+                                "center",
+                                "left",
+                                "right"
+                            ],
+                            "type": "string"
+                        }
                     ],
-                    "type": "string"
+                    "description": "Text justification option to align the text."
                 },
                 "keepUpright": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fall"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fany"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
@@ -12947,7 +18073,28 @@
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                         },
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FequalTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThanOrEqualTo"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThanOrEqualTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fnot"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnotEqualTo"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
@@ -12979,6 +18126,9 @@
                 },
                 "label": {
                     "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
@@ -13027,6 +18177,9 @@
                 "letterSpacing": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -13034,6 +18187,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -13049,6 +18205,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -13067,6 +18226,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -13097,6 +18259,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -13125,6 +18290,9 @@
                 "lineHeight": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -13132,6 +18300,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -13147,6 +18318,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -13165,6 +18339,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -13195,6 +18372,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -13223,6 +18403,9 @@
                 "maxAngle": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -13230,6 +18413,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -13245,6 +18431,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -13263,6 +18452,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -13293,6 +18485,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -13312,6 +18507,9 @@
                 "maxWidth": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -13319,6 +18517,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -13334,6 +18535,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -13352,6 +18556,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -13382,6 +18589,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -13404,6 +18614,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -13411,6 +18624,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -13426,6 +18642,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -13444,6 +18663,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -13474,6 +18696,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -13492,6 +18717,9 @@
                         {
                             "anyOf": [
                                 {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                                },
+                                {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                                 },
                                 {
@@ -13499,6 +18727,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -13514,6 +18745,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -13532,6 +18766,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -13562,6 +18799,9 @@
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                                },
+                                {
+                                    "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                                 },
                                 {
                                     "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -13583,15 +18823,64 @@
                     "type": "array"
                 },
                 "offsetAnchor": {
-                    "description": "Property relevant for mapbox-styles.\nCompare https://docs.mapbox.com/mapbox-gl-js/style-spec/#paint-symbol-icon-translate-anchor",
-                    "enum": [
-                        "map",
-                        "viewport"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                        },
+                        {
+                            "enum": [
+                                "map",
+                                "viewport"
+                            ],
+                            "type": "string"
+                        }
                     ],
-                    "type": "string"
+                    "description": "Property relevant for mapbox-styles.\nCompare https://docs.mapbox.com/mapbox-gl-js/style-spec/#paint-symbol-icon-translate-anchor"
                 },
                 "opacity": {
                     "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
@@ -13600,6 +18889,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -13615,6 +18907,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -13633,6 +18928,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -13665,6 +18963,9 @@
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
                         },
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
                         },
                         {
@@ -13682,7 +18983,16 @@
                 "optional": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fall"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fany"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
@@ -13691,7 +19001,28 @@
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                         },
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FequalTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThanOrEqualTo"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThanOrEqualTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fnot"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnotEqualTo"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"
@@ -13717,6 +19048,9 @@
                 "padding": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
                         {
@@ -13724,6 +19058,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -13739,6 +19076,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -13757,6 +19097,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -13787,6 +19130,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -13804,16 +19150,65 @@
                     "description": "Size of the additional area around the text bounding box used for detecting\nsymbol collisions."
                 },
                 "pitchAlignment": {
-                    "description": "Property relevant for mapbox-styles.\nCompare https://docs.mapbox.com/mapbox-gl-js/style-spec/#layout-symbol-text-pitch-alignment",
-                    "enum": [
-                        "auto",
-                        "map",
-                        "viewport"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                        },
+                        {
+                            "enum": [
+                                "auto",
+                                "map",
+                                "viewport"
+                            ],
+                            "type": "string"
+                        }
                     ],
-                    "type": "string"
+                    "description": "Property relevant for mapbox-styles.\nCompare https://docs.mapbox.com/mapbox-gl-js/style-spec/#layout-symbol-text-pitch-alignment"
                 },
                 "rotate": {
                     "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
@@ -13822,6 +19217,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -13837,6 +19235,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -13855,6 +19256,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -13885,6 +19289,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
@@ -13902,16 +19309,65 @@
                     "description": "The rotation of the Symbolizer in degrees. Value should be between 0 and 360."
                 },
                 "rotationAlignment": {
-                    "description": "Property relevant for mapbox-styles.\nCompare https://docs.mapbox.com/mapbox-gl-js/style-spec/#layout-symbol-text-rotation-alignment",
-                    "enum": [
-                        "auto",
-                        "map",
-                        "viewport"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                        },
+                        {
+                            "enum": [
+                                "auto",
+                                "map",
+                                "viewport"
+                            ],
+                            "type": "string"
+                        }
                     ],
-                    "type": "string"
+                    "description": "Property relevant for mapbox-styles.\nCompare https://docs.mapbox.com/mapbox-gl-js/style-spec/#layout-symbol-text-rotation-alignment"
                 },
                 "size": {
                     "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
                         },
@@ -13920,6 +19376,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Facos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fadd"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fasin"
@@ -13935,6 +19394,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcos"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdiv"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fexp"
@@ -13953,6 +19415,9 @@
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmodulo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fmul"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fpi"
@@ -13985,6 +19450,9 @@
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrLength"
                         },
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fsub"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Ftan"
                         },
                         {
@@ -14000,18 +19468,73 @@
                     "description": "The fontsize in pixels."
                 },
                 "transform": {
-                    "description": "Specifies how to capitalize text, similar to the CSS text-transform property.",
-                    "enum": [
-                        "lowercase",
-                        "none",
-                        "uppercase"
+                    "anyOf": [
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnumberFormat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrAbbreviate"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrCapitalize"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrConcat"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrDefaultIfBlank"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrReplace"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrStripAccents"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstring"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrSubstringStart"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToLowerCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrToUpperCase"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FstrTrim"
+                        },
+                        {
+                            "enum": [
+                                "lowercase",
+                                "none",
+                                "uppercase"
+                            ],
+                            "type": "string"
+                        }
                     ],
-                    "type": "string"
+                    "description": "Specifies how to capitalize text, similar to the CSS text-transform property."
                 },
                 "visibility": {
                     "anyOf": [
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fcase"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fproperty"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fall"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fany"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fbetween"
@@ -14020,7 +19543,28 @@
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fdouble2bool"
                         },
                         {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FequalTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FgreaterThanOrEqualTo"
+                        },
+                        {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/Fin"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThan"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FlessThanOrEqualTo"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/Fnot"
+                        },
+                        {
+                            "$ref": "http://geostyler/geostyler-style.json#/definitions/FnotEqualTo"
                         },
                         {
                             "$ref": "http://geostyler/geostyler-style.json#/definitions/FparseBoolean"

--- a/typeguards.ts
+++ b/typeguards.ts
@@ -175,7 +175,7 @@ export const isGrayChannel = (got: any): got is GrayChannel => {
 
 // Functions
 export const isGeoStylerNumberFunction = (got: any): got is GeoStylerNumberFunction => {
-  return [
+  const functionNames: GeoStylerNumberFunction['name'][] = [
     'abs',
     'acos',
     'add',
@@ -206,11 +206,12 @@ export const isGeoStylerNumberFunction = (got: any): got is GeoStylerNumberFunct
     'tan',
     'toDegrees',
     'toRadians'
-  ].includes(got?.name);
+  ];
+  return functionNames.includes(got?.name);
 };
 
 export const isGeoStylerStringFunction = (got: any): got is GeoStylerStringFunction => {
-  return [
+  const functionNames: GeoStylerStringFunction['name'][] = [
     'numberFormat',
     'strAbbreviate',
     'strCapitalize',
@@ -223,17 +224,18 @@ export const isGeoStylerStringFunction = (got: any): got is GeoStylerStringFunct
     'strToLowerCase',
     'strToUpperCase',
     'strTrim'
-  ].includes(got?.name);
+  ];
+  return functionNames.includes(got?.name);
 };
 
 export const isGeoStylerBooleanFunction = (got: any): got is GeoStylerBooleanFunction => {
-  return [
+  const functionNames: GeoStylerBooleanFunction['name'][] = [
     'all',
     'any',
     'between',
     'double2bool',
     'equalTo',
-    'greatherThan',
+    'greaterThan',
     'greaterThanOrEqualTo',
     'in',
     'lessThan',
@@ -245,14 +247,16 @@ export const isGeoStylerBooleanFunction = (got: any): got is GeoStylerBooleanFun
     'strEqualsIgnoreCase',
     'strMatches',
     'strStartsWith'
-  ].includes(got?.name);
+  ];
+  return functionNames.includes(got?.name);
 };
 
 export const isGeoStylerUnknownFunction = (got: any): got is GeoStylerUnknownFunction => {
-  return [
+  const functionNames: GeoStylerUnknownFunction['name'][] = [
     'case',
     'property',
-  ].includes(got?.name);
+  ];
+  return functionNames.includes(got?.name);
 };
 
 export const isGeoStylerFunction = (got: any): got is GeoStylerFunction => {


### PR DESCRIPTION
This fixes a typo in `isGeoStylerBooleanFunction` which causes bugs when parsing `isGreaterThan` functions.
This also adds typing to avoid this kind of bugs and adds the updated schema.json.