### PR TITLE
feat: add metadata block to geostyler style

### DIFF
--- a/style.ts
+++ b/style.ts
@@ -750,6 +750,9 @@ export interface Rule {
 export interface Style {
   name: string;
   rules: Rule[];
+  metadata?: {
+    [key: string]: any;
+  };
 }
 
 /**


### PR DESCRIPTION
This adds a metadata block to the Style interface that allows adding arbitrary metadata. This metadata can be used in the parsers for things that are not directly related to the styling but are still necessary for parsing, e.g. keeping the source information of mapbox styles for referencing them when parsing.