### PR TITLE
Add support for image sprites

### DIFF
--- a/style.ts
+++ b/style.ts
@@ -389,17 +389,13 @@ export type Sprite = {
    */
   source: Expression<string>;
   /**
-   * The starting position of the sprite to cut out. Origing [0, 0] is top left.
+   * The starting position of the sprite to cut out. Origing [0, 0] is top left in pixels.
    */
   position: [Expression<number>, Expression<number>];
   /**
-   * The width of the sprite.
+   * The size of the sprite [width, height] in pixels.
    */
-  width: Expression<number>;
-  /**
-   * The height of the sprite.
-   */
-  height: Expression<number>;
+  size: [Expression<number>, Expression<number>];
 };
 
 /**

--- a/style.ts
+++ b/style.ts
@@ -381,6 +381,28 @@ export interface TextSymbolizer extends BasePointSymbolizer {
 }
 
 /**
+ * Configuration for a sprite image.
+ */
+export type Sprite = {
+  /**
+   * A path/URL to the sprite image file.
+   */
+  source: Expression<string>;
+  /**
+   * The starting position of the sprite to cut out. Origing [0, 0] is top left.
+   */
+  position: [Expression<number>, Expression<number>];
+  /**
+   * The width of the sprite.
+   */
+  width: Expression<number>;
+  /**
+   * The height of the sprite.
+   */
+  height: Expression<number>;
+};
+
+/**
  * An IconSymbolizer describes the style representation of POINT data if styled
  * with a specific icon.
  */
@@ -421,9 +443,9 @@ export interface IconSymbolizer extends BasePointSymbolizer {
    */
   haloOpacity?: Expression<number>;
   /**
-   * A path/URL to the icon image file.
+   * A path/URL to the icon image file or a {@link Sprite} configuration.
    */
-  image?: Expression<string>;
+  image?: Expression<string> | Sprite;
   /**
    * An optional configuration for the image format as MIME type.
    * This might be needed if the image(path) has no filending specified. e.g. http://myserver/getImage


### PR DESCRIPTION
This adds support for [sprites](https://en.wikipedia.org/wiki/Sprite_(computer_graphics)) to the IconSymbolizer.
It will enhance parsing mapbox styles as they fully rely on sprites: https://docs.mapbox.com/style-spec/reference/sprite/#sprite-files

IMHO it is a breaking change as the UI and other parsers will fail handling a style with a `Sprite`.

BREAKING CHANGE:
IconSymbolizer.image can be a Sprite

Related to https://github.com/geostyler/geostyler-mapbox-parser/issues/290