### PR TITLE
feat: added placement for TextSymbolizer

### DIFF
--- a/style.ts
+++ b/style.ts
@@ -378,6 +378,10 @@ export interface TextSymbolizer extends BasePointSymbolizer {
    * on the font-family you are using.
    */
   fontWeight?: Expression<'normal' | 'bold'>;
+  /**
+   * Specifies label placement relative to its geometry.
+   */
+  placement?: Expression<'point' | 'line' | 'line-center'>;
 }
 
 /**


### PR DESCRIPTION
This adds the placement property for TextSymbolizer. Allowed values were taken from MapBox style. 
Read: https://docs.mapbox.com/style-spec/reference/layers/#layout-symbol-symbol-placement 