### PR TITLE
Try to fix release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@typescript-eslint/eslint-plugin-tslint": "^6.10.0",
         "@typescript-eslint/parser": "^6.10.0",
         "babel-jest": "^29.7.0",
+        "conventional-changelog-conventionalcommits": "^6.1.0",
         "core-js": "^3.33.2",
         "eslint": "^8.53.0",
         "jest": "^29.7.0",
@@ -39,8 +40,8 @@
         "typescript-json-schema": "^0.62.0"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=9.0.0"
+        "node": ">=16.0.0",
+        "npm": ">=6.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/geostyler"
@@ -1871,6 +1872,18 @@
       },
       "engines": {
         "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/config-conventional/node_modules/conventional-changelog-conventionalcommits": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
+      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
+      "dev": true,
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@commitlint/config-validator": {
@@ -5670,15 +5683,15 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
-      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-6.1.0.tgz",
+      "integrity": "sha512-3cS3GEtR78zTfMzk0AizXKKIdN4OvSh7ibNz6/DPbhWWQu7LqE/8+/GqSodV+sywUR2gpJAdP/1JFf4XtN7Zpw==",
       "dev": true,
       "dependencies": {
         "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=14"
       }
     },
     "node_modules/conventional-changelog-writer": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@typescript-eslint/eslint-plugin-tslint": "^6.10.0",
     "@typescript-eslint/parser": "^6.10.0",
     "babel-jest": "^29.7.0",
+    "conventional-changelog-conventionalcommits": "^6.1.0",
     "core-js": "^3.33.2",
     "eslint": "^8.53.0",
     "jest": "^29.7.0",


### PR DESCRIPTION
This sets conventional-changelog-conventionalcommits to version 6 to try compensate the issue https://github.com/semantic-release/commit-analyzer/issues/517 which is blocking our release script.