### PR TITLE
Allow numbers in the in function

### DIFF
--- a/functions.ts
+++ b/functions.ts
@@ -300,7 +300,7 @@ export interface FgreaterThanOrEqualTo extends FunctionCall<boolean> {
  */
 export interface Fin extends FunctionCall<boolean> {
   name: 'in';
-  args: Expression<string>[];
+  args: Expression<string | number>[];
 };
 
 /**


### PR DESCRIPTION
This allows numbers as arguments of the `in` function so this becomes a valid function:

```ts
{
  name: 'in',
  args: [
    {
      name: 'property',
      args: [
        'visualisatiecode'
      ]
    },
    10721,
    10720
  ]
}
```