### PR TITLE
Add missing property sizeUnit to TextSymbolizer

### DIFF
--- a/src/style.ts
+++ b/src/style.ts
@@ -376,9 +376,13 @@ export interface TextSymbolizer extends BasePointSymbolizer {
    */
   rotationAlignment?: Expression<'map' | 'viewport' | 'auto'>;
   /**
-   * The fontsize in pixels.
+   * The fontsize (pixels if sizeUnit is not defined).
    */
   size?: Expression<number>;
+  /**
+   * Unit to use for the size. If missing, pixels are assumed.
+   */
+  sizeUnit?: DistanceUnit;
   /**
    * Specifies how to capitalize text, similar to the CSS text-transform property.
    */


### PR DESCRIPTION
All symbolizer-properties holding a size have a related unit-property (e.g. `strokeWidth`/`strokeWidthUnit`), even other properties of `TextSymbolizer `(e.g. `haloWidth`/`haloWidthUnit`). But the property `TextSymbolizer.size` hasn't. So it isn't possible to
read style-definitions with ground-based text-sizes (e.g. QML `RenderMetersInMapUnits` or SLD attribute `uom="http://www.opengeospatial.org/se/units/metre"`).
For now, it's just a prerequisite for coming implementations of this in following pull-requests.