### PR TITLE
feat: add startPoint, endPoint, centroid geometry functions

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -1,7 +1,8 @@
 import {
   FunctionCall,
   Expression,
-  PropertyType
+  PropertyType,
+  Geometry
 } from './style';
 
 export type GeoStylerFunction = GeoStylerNumberFunction |
@@ -90,12 +91,45 @@ FstrStartsWith;
 /**
  * An expression of a function that returns a geometry.
  */
-export type GeoStylerGeometryFunction = GeoStylerUnknownFunction;
+export type GeoStylerGeometryFunction = GeoStylerUnknownFunction |
+  FstartPoint |
+  FendPoint |
+  Fcentroid;
 
 /**
  * An expression of a function that returns an unknown type.
  */
 export type GeoStylerUnknownFunction = Fcase | Fstep | Fproperty | Fcustom;
+
+/**
+ * Returns the start point of the specified geometry.
+ */
+export interface FstartPoint extends FunctionCall<Geometry> {
+  name: 'startPoint';
+  args: [
+    Expression<Geometry>
+  ]
+};
+
+/**
+ * Returns the end point of the specified geometry.
+ */
+export interface FendPoint extends FunctionCall<Geometry> {
+  name: 'endPoint';
+  args: [
+    Expression<Geometry>
+  ]
+};
+
+/**
+ * Returns the centroid of the specified geometry.
+ */
+export interface Fcentroid extends FunctionCall<Geometry> {
+  name: 'centroid';
+  args: [
+    Expression<Geometry>
+  ]
+};
 
 /**
  * The absolute value of the specified number value

--- a/src/style.ts
+++ b/src/style.ts
@@ -32,7 +32,8 @@ export interface ScaleDenominator {
 export interface FunctionCall<T> {
   name: T extends string ? GeoStylerStringFunction['name'] :
     T extends number ? GeoStylerNumberFunction['name'] :
-    GeoStylerBooleanFunction['name'];
+    T extends boolean ? GeoStylerBooleanFunction['name'] :
+    GeoStylerGeometryFunction['name'];
   args: Expression<PropertyType>[];
 };
 
@@ -274,7 +275,7 @@ export interface MarkSymbolizer extends BasePointSymbolizer {
   * Encodes a dash pattern as an array of numbers. Odd-indexed numbers (first,
   * third, etc) determine the length in pixels to draw the line, and even-indexed
   * numbers (second, fourth, etc) determine the length in pixels to blank out
-  * the line. 
+  * the line.
   * If the array is empty, no dash pattern will be applied.
   */
   strokeDasharray?: Expression<number>[];

--- a/src/typeguards.spec.ts
+++ b/src/typeguards.spec.ts
@@ -2,6 +2,7 @@ import {
   GeoStylerBooleanFunction,
   GeoStylerNumberFunction,
   GeoStylerStringFunction,
+  GeoStylerGeometryFunction,
   GeoStylerUnknownFunction
 } from './functions';
 import {
@@ -33,6 +34,7 @@ import {
   isFilter,
   isGeoStylerBooleanFunction,
   isGeoStylerFunction,
+  isGeoStylerGeometryFunction,
   isGeoStylerNumberFunction,
   isGeoStylerStringFunction,
   isGeoStylerUnknownFunction,
@@ -236,6 +238,14 @@ const booleanFunction: GeoStylerBooleanFunction = {
   }, 'Berlin', 'Hamburg', 'Bremen']
 };
 
+const geometryFunction: GeoStylerGeometryFunction = {
+  name: 'centroid',
+  args: [{
+    name: 'property',
+    args: ['geom'],
+  }]
+};
+
 const unknownFunction: GeoStylerUnknownFunction = {
   name: 'property',
   args: ['city']
@@ -294,6 +304,7 @@ const thingsToTest = [
   numberFunction2,
   stringFunction,
   booleanFunction,
+  geometryFunction,
   unknownFunction,
   customFunction,
   spriteImage
@@ -369,6 +380,8 @@ describe('typeguards', () => {
       negationFilter1,
       negationFilter2,
       booleanFunction,
+      unknownFunction,
+      customFunction,
       tru
     ];
     thingsToTest.forEach(thing => {
@@ -493,7 +506,9 @@ describe('typeguards', () => {
   it('isGeoStylerNumberFunction', () => {
     const expectedMatches: any[] = [
       numberFunction1,
-      numberFunction2
+      numberFunction2,
+      unknownFunction,
+      customFunction,
     ];
     thingsToTest.forEach(thing => {
       expect(isGeoStylerNumberFunction(thing)).toBe(expectedMatches.includes(thing));
@@ -501,7 +516,9 @@ describe('typeguards', () => {
   });
   it('isGeoStylerStringFunction', () => {
     const expectedMatches: any[] = [
-      stringFunction
+      stringFunction,
+      unknownFunction,
+      customFunction,
     ];
     thingsToTest.forEach(thing => {
       expect(isGeoStylerStringFunction(thing)).toBe(expectedMatches.includes(thing));
@@ -510,10 +527,22 @@ describe('typeguards', () => {
   it('isGeoStylerBooleanFunction', () => {
     const expectedMatches: any[] = [
       booleanFunction,
-      functionAsFilter
+      functionAsFilter,
+      unknownFunction,
+      customFunction,
     ];
     thingsToTest.forEach(thing => {
       expect(isGeoStylerBooleanFunction(thing)).toBe(expectedMatches.includes(thing));
+    });
+  });
+  it('isGeoStylerGeometryFunction', () => {
+    const expectedMatches: any[] = [
+      geometryFunction,
+      unknownFunction,
+      customFunction,
+    ];
+    thingsToTest.forEach(thing => {
+      expect(isGeoStylerGeometryFunction(thing)).toBe(expectedMatches.includes(thing));
     });
   });
   it('isGeoStylerUnknownFunction', () => {
@@ -531,6 +560,7 @@ describe('typeguards', () => {
       numberFunction2,
       stringFunction,
       booleanFunction,
+      geometryFunction,
       unknownFunction,
       customFunction,
       functionAsFilter

--- a/src/typeguards.ts
+++ b/src/typeguards.ts
@@ -53,7 +53,8 @@ import {
   PointSymbolizer,
   Symbolizer,
   FunctionCall,
-  Sprite
+  Sprite,
+  GeoStylerGeometryFunction
 } from './index';
 
 export const isExpression = (got: any): got is Expression<any> => {
@@ -225,7 +226,7 @@ export const isGeoStylerNumberFunction = (got: any): got is GeoStylerNumberFunct
     'toNumber',
     'toRadians'
   ];
-  return functionNames.includes(got?.name);
+  return isGeoStylerUnknownFunction(got) || functionNames.includes(got?.name);
 };
 
 export const isGeoStylerStringFunction = (got: any): got is GeoStylerStringFunction => {
@@ -244,7 +245,7 @@ export const isGeoStylerStringFunction = (got: any): got is GeoStylerStringFunct
     'strToUpperCase',
     'strTrim'
   ];
-  return functionNames.includes(got?.name);
+  return isGeoStylerUnknownFunction(got) || functionNames.includes(got?.name);
 };
 
 export const isGeoStylerBooleanFunction = (got: any): got is GeoStylerBooleanFunction => {
@@ -267,7 +268,16 @@ export const isGeoStylerBooleanFunction = (got: any): got is GeoStylerBooleanFun
     'strMatches',
     'strStartsWith'
   ];
-  return functionNames.includes(got?.name);
+  return isGeoStylerUnknownFunction(got) || functionNames.includes(got?.name);
+};
+
+export const isGeoStylerGeometryFunction = (got: any): got is GeoStylerGeometryFunction => {
+  const functionNames: GeoStylerGeometryFunction['name'][] = [
+    'centroid',
+    'endPoint',
+    'startPoint'
+  ];
+  return isGeoStylerUnknownFunction(got) || functionNames.includes(got?.name);
 };
 
 export const isGeoStylerUnknownFunction = (got: any): got is GeoStylerUnknownFunction => {
@@ -284,6 +294,7 @@ export const isGeoStylerFunction = (got: any): got is GeoStylerFunction => {
   return isGeoStylerBooleanFunction(got) ||
     isGeoStylerNumberFunction(got) ||
     isGeoStylerStringFunction(got) ||
+    isGeoStylerGeometryFunction(got) ||
     isGeoStylerUnknownFunction(got);
 };
 


### PR DESCRIPTION
feat: add startPoint, endPoint, centroid geometry functions

BREAKING CHANGE: This adds FstartPoint, FendPoint and Fcentroid to GeoStylerGeometryFunction. Previous checks on
GeoStylerGeometryFunction might now need additional checks for distinguishing the different functions.
This also adds GeoStylerGeometryFunction to FunctionCall. Previous checks on FunctionCall might now need additional checks for the added interface.
Typeguards for the typed GeoStyler functions isGeoStylerBooleanFunction, isGeoStylerStringFunction, and isGeoStylerNumberFunction now also check for GeoStylerUnknownFunction, thereby following their actual types. Checks using these typeguards might need to be narrowed down by additionally checking on the falseness of isGeoStylerUnknownFunction.